### PR TITLE
로그인 및 회원가입 직후 방 가입 하는 api기능 만들었습니다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	//Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	//swagger-ui
 	//http://localhost:8080/swagger-ui/index.html  << 반드시 이 url 로 접속
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'

--- a/src/main/java/com/dnd12th_4/pickitalki/common/converter/UUIDConverter.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/converter/UUIDConverter.java
@@ -1,0 +1,25 @@
+package com.dnd12th_4.pickitalki.common.converter;
+
+import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
+import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
+
+import java.util.UUID;
+
+public class UUIDConverter {
+
+    public static UUID toUUID(String uuidStr) {
+
+        if(uuidStr==null|| uuidStr.isEmpty()){
+            throw new ApiException(ErrorCode.BAD_REQUEST,"UUID convertToUUID 에러");
+        }
+
+        if (uuidStr.length() == 32) {
+            // UUID 8-4-4-4-12 형식으로 변환
+            uuidStr = uuidStr.replaceFirst(
+                    "(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})",
+                    "$1-$2-$3-$4-$5"
+            );
+        }
+        return UUID.fromString(uuidStr);
+    }
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/common/interceptor/JwtInterceptor.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/interceptor/JwtInterceptor.java
@@ -1,6 +1,8 @@
 package com.dnd12th_4.pickitalki.common.interceptor;
 
 import com.dnd12th_4.pickitalki.common.token.JwtProvider;
+import com.dnd12th_4.pickitalki.presentation.error.TokenErrorCode;
+import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +24,10 @@ public class JwtInterceptor implements HandlerInterceptor {
                 jwtProvider.validateToken(token);
 
             } catch (Exception e) {
-                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "유효하지 않는 토큰입니다");
-                return false;
+                throw new ApiException(TokenErrorCode.INVALID_TOKEN,"boolean preHandle 27번째 에러");
             }
-        } else {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "토큰이 없습니다.");
-            return false;
+        } else{
+            throw new ApiException(TokenErrorCode.AUTHORIZATION_TOKEN_NOT_FOUND,"boolean preHandle 27번째 에러");
         }
         return true;
     }
@@ -39,6 +39,6 @@ public class JwtInterceptor implements HandlerInterceptor {
             return bearerToken;
 
         }
-        return null;
+       return null;
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/common/token/JwtProvider.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/token/JwtProvider.java
@@ -53,9 +53,9 @@ public class JwtProvider {
                     .parseClaimsJws(token)
                     .getBody();
         } catch (ExpiredJwtException e) {
-            throw new ApiException(TokenErrorCode.EXPIRED_TOKEN,e);
+            throw new ApiException(TokenErrorCode.EXPIRED_TOKEN,"Claims validateToken에서 56줄 에러");
         } catch (JwtException e) {
-            throw new ApiException(TokenErrorCode.INVALID_TOKEN,e);
+            throw new ApiException(TokenErrorCode.INVALID_TOKEN,"Claims validateToken에서 58줄 에러");
         }
     }
 

--- a/src/main/java/com/dnd12th_4/pickitalki/common/token/JwtProvider.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/token/JwtProvider.java
@@ -70,7 +70,7 @@ public class JwtProvider {
         } catch (ExpiredJwtException e) {
             return true;
         } catch (JwtException e) {
-            throw new ApiException(TokenErrorCode.INVALID_TOKEN,e);
+            throw new ApiException(TokenErrorCode.INVALID_TOKEN,"boolean isTokenExpired 73번째 에러 발생");
         }
     }
 

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -2,8 +2,10 @@ package com.dnd12th_4.pickitalki.controller.channel;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
 import com.dnd12th_4.pickitalki.common.converter.UUIDConverter;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.domain.channel.Channel;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
@@ -12,7 +14,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
+import java.util.List;
+
 
 @RestController
 @RequiredArgsConstructor
@@ -49,11 +52,39 @@ public class ChannelController {
             @RequestParam("channelUuid") @Valid String channelUuid
     ) {
 
-
-
-        ChannelMember channelMember=channelService.invited(memberId, UUIDConverter.toUUID(channelUuid));
+        ChannelMember channelMember = channelService.invited(memberId, UUIDConverter.toUUID(channelUuid));
         ChannelMemberResponse channelMemberResponse = new ChannelMemberResponse(channelMember.getId());
 
         return Api.OK(channelMemberResponse);
     }
+
+    @GetMapping("/invited/room/all")
+    public Api<List<ChannelShowAllResponse>> invitedRoomAll(
+            @MemberId Long memberId
+    ) {
+        List<ChannelShowAllResponse> channelShowAllResponses = channelService.myRooms(memberId, ChannelControllerEnums.INVITEDALL);
+
+        return Api.OK(channelShowAllResponses);
+    }
+
+    @GetMapping("/make/room/all")
+    public Api<List<ChannelShowAllResponse>> makeRoomAll(
+            @MemberId Long memberId
+    ) {
+        List<ChannelShowAllResponse> channelShowAllResponses = channelService.myRooms(memberId, ChannelControllerEnums.MADEALL);
+
+        return Api.OK(channelShowAllResponses);
+    }
+
+    @GetMapping("/room/all")
+    public Api<List<ChannelShowAllResponse>> roomAll(
+            @MemberId Long memberId
+    ) {
+        List<ChannelShowAllResponse> channelShowAllResponses = channelService.myRooms(memberId, ChannelControllerEnums.SHOWALL);
+        return Api.OK(channelShowAllResponses);
+    }
 }
+
+
+
+

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -1,7 +1,10 @@
 package com.dnd12th_4.pickitalki.controller.channel;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.domain.channel.Channel;
+import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.channel.ChannelService;
 import jakarta.validation.Valid;
@@ -18,12 +21,24 @@ public class ChannelController {
     private final ChannelService channelService;
 
     @PostMapping("/make/room")
-    public Api<Object> makeRoom(
+    public Api<ChannelMemberResponse> makeRoom(
             @MemberId Long memberId,
             @RequestParam("channelName") @Valid String channelName
     ) {
-        Channel channel = channelService.save(memberId, channelName);
+        ChannelMember channelMember = channelService.save(memberId, channelName);
+        ChannelMemberResponse channelMemberResponse = new ChannelMemberResponse(channelMember.getId());
 
-        return Api.OK(channel.getUuid());
+        return Api.OK(channelMemberResponse);
+    }
+
+    @PostMapping("/codename/{channelMemberId}")
+    public Api<ChannelResponse> codeName(
+            @PathVariable Long channelMemberId,
+            @RequestParam("codeName") @Valid String codeName
+    ) {
+        Channel channel = channelService.updateCodeName(channelMemberId, codeName);
+        ChannelResponse channelResponse = new ChannelResponse(channel.getUuid());
+
+        return Api.OK(channelResponse);
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -1,6 +1,7 @@
 package com.dnd12th_4.pickitalki.controller.channel;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.common.converter.UUIDConverter;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.domain.channel.Channel;
@@ -40,5 +41,19 @@ public class ChannelController {
         ChannelResponse channelResponse = new ChannelResponse(channel.getUuid());
 
         return Api.OK(channelResponse);
+    }
+
+    @PostMapping("/invited/room")
+    public Api<ChannelMemberResponse> invitedRoom(
+            @MemberId Long memberId,
+            @RequestParam("channelUuid") @Valid String channelUuid
+    ) {
+
+
+
+        ChannelMember channelMember=channelService.invited(memberId, UUIDConverter.toUUID(channelUuid));
+        ChannelMemberResponse channelMemberResponse = new ChannelMemberResponse(channelMember.getId());
+
+        return Api.OK(channelMemberResponse);
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -1,0 +1,29 @@
+package com.dnd12th_4.pickitalki.controller.channel;
+
+import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.domain.channel.Channel;
+import com.dnd12th_4.pickitalki.presentation.api.Api;
+import com.dnd12th_4.pickitalki.service.channel.ChannelService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/channels")
+public class ChannelController {
+
+    private final ChannelService channelService;
+
+    @PostMapping("/make/room")
+    public Api<Object> makeRoom(
+            @MemberId Long memberId,
+            @RequestParam("channelName") @Valid String channelName
+    ) {
+        Channel channel = channelService.save(memberId, channelName);
+
+        return Api.OK(channel.getUuid());
+    }
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelControllerEnums.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelControllerEnums.java
@@ -1,0 +1,9 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto;
+
+
+public enum ChannelControllerEnums {
+    SHOWALL,
+    INVITEDALL,
+    MADEALL
+    ;
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberResponse.java
@@ -1,0 +1,13 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChannelMemberResponse {
+
+    private Long channelMemberId;
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelResponse.java
@@ -1,0 +1,15 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChannelResponse {
+
+    private UUID chanelUuid;
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelShowAllResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelShowAllResponse.java
@@ -1,0 +1,19 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChannelShowAllResponse {
+
+    private String channelRoomName;
+    private String channelOwnerName;
+    private Long countPerson;
+    private Long singalCount;
+
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/KakaoAuthExchangeController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/KakaoAuthExchangeController.java
@@ -52,7 +52,7 @@ public class KakaoAuthExchangeController {
 
     private void executeCookie(HttpServletResponse response, String refreshToken) {
         if (refreshToken == null || refreshToken.isEmpty()) {
-            throw new ApiException(TokenErrorCode.TOKEN_EXCEPTION);
+            throw new ApiException(TokenErrorCode.TOKEN_EXCEPTION,"void executeCookie 55번째줄 에러");
         }
 
         Cookie cookie = cookieProvider.makeNewCookie("refreshToken", refreshToken);

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/MemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/MemberController.java
@@ -13,12 +13,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/members")
 public class MemberController {
 
     private final MemberService memberService;
 
-    @PostMapping("/members/name")
+    @PostMapping("/name")
     public Api<String> registerName(
             @MemberId Long memberId,
             @RequestParam("name") @NotBlank String name

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/MemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/MemberController.java
@@ -1,0 +1,31 @@
+package com.dnd12th_4.pickitalki.controller.login;
+
+import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.domain.member.Member;
+import com.dnd12th_4.pickitalki.presentation.api.Api;
+import com.dnd12th_4.pickitalki.service.login.MemberService;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/members/name")
+    public Api<String> registerName(
+            @MemberId Long memberId,
+            @RequestParam("name") @NotBlank String name
+    ) {
+        Member member = memberService.updateName(memberId, name);
+
+        return Api.OK(member.getNickName());
+    }
+
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/TokenAuthController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/TokenAuthController.java
@@ -29,7 +29,6 @@ public class TokenAuthController {
     public ResponseEntity<Map<String, String>> refreshAccessToken(
             @CookieValue("refreshToken") String refreshToken,
             HttpServletResponse response) {
-
         Member user = kaKaoSignUpService.findUser(refreshToken);
 
         if (jwtProvider.isTokenExpired(user.getRefreshToken())) {

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/TokenAuthController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/TokenAuthController.java
@@ -3,6 +3,8 @@ package com.dnd12th_4.pickitalki.controller.login;
 import com.dnd12th_4.pickitalki.common.cookie.CookieProvider;
 import com.dnd12th_4.pickitalki.common.token.JwtProvider;
 import com.dnd12th_4.pickitalki.domain.member.Member;
+import com.dnd12th_4.pickitalki.presentation.error.TokenErrorCode;
+import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import com.dnd12th_4.pickitalki.service.login.KaKaoSignUpService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
@@ -34,8 +36,7 @@ public class TokenAuthController {
         if (jwtProvider.isTokenExpired(user.getRefreshToken())) {
             executeExpiredCookie(response, user);
 
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(Map.of("message", "Refresh token expired. Please log in again."));
+             throw new ApiException(TokenErrorCode.EXPIRED_TOKEN,"ResponseEntity refreshAccessToken 에러");
         }
 
         String newAccessToken = jwtProvider.createAccessToken(user.getId());

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -4,6 +4,7 @@ import com.dnd12th_4.pickitalki.domain.BaseEntity;
 import com.dnd12th_4.pickitalki.domain.question.Question;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 import org.springframework.data.domain.Persistable;
 
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ import static java.util.Objects.isNull;
 @Getter
 @Table(name = "channels")
 @Entity
+@SuperBuilder
 public class Channel extends BaseEntity implements Persistable<String> {
 
     @Id
@@ -24,10 +26,10 @@ public class Channel extends BaseEntity implements Persistable<String> {
     @Column(nullable = false, length = 10)
     private String name;
 
-    @OneToMany(mappedBy = "channel", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "channel")
     private List<ChannelMember> channelMembers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "channel", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "channel")
     private List<Question> questions = new ArrayList<>();
 
     protected Channel() {}
@@ -50,5 +52,16 @@ public class Channel extends BaseEntity implements Persistable<String> {
     @Override
     public String getId() {
         return uuid.toString();
+    }
+
+    public void makeChannelMember(ChannelMember channelMember){
+        if(channelMembers==null){
+            channelMembers = new ArrayList<>();
+        }
+
+        if(channelMember!=null && !channelMembers.contains(channelMember)){
+            channelMembers.add(channelMember);
+            channelMember.makeChannel(this);
+        }
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -19,11 +19,11 @@ public class ChannelMember extends BaseEntity {
     private Long id;
 
     @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "channel_uuid", nullable = false)
     private Channel channel;
 
     @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
-    @JoinColumn(nullable = false)
+    @JoinColumn(name = "member_id" ,nullable = false)
     private Member member;
 
     @Column(nullable=true)

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -3,33 +3,36 @@ package com.dnd12th_4.pickitalki.domain.channel;
 
 import com.dnd12th_4.pickitalki.domain.BaseEntity;
 import com.dnd12th_4.pickitalki.domain.member.Member;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
 @Table(name = "channel_members")
 @Entity
+@SuperBuilder
 public class ChannelMember extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinColumn(nullable = false)
     private Channel channel;
 
-    @ManyToOne
+    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     @JoinColumn(nullable = false)
     private Member member;
 
+    @Column(nullable=true)
+    private String memberCodeName;
+
+    @Column(columnDefinition = "varchar(50)", nullable = false)
+    @Enumerated(EnumType.STRING)
     private Role role;
+
 
     protected ChannelMember() {
     }
@@ -39,6 +42,28 @@ public class ChannelMember extends BaseEntity {
         this.channel = channel;
         this.member = member;
         this.role = role;
+    }
+
+    public void setMemberCodeName(String memberCodeName) {
+        this.memberCodeName = memberCodeName;
+    }
+
+    public void makeMember(Member member){
+        if(member==null)return;
+
+        if(this.member!=member){
+            this.member=member;
+            member.makeChannelMember(this);
+        }
+    }
+
+    public void makeChannel(Channel channel){
+        if(channel ==null)return;
+
+        if(this.channel!= channel){
+            this.channel = channel;
+            channel.makeChannelMember(this);
+        }
     }
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
@@ -2,5 +2,8 @@ package com.dnd12th_4.pickitalki.domain.channel;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ChannelMemberRepository  extends JpaRepository<ChannelMember,Long> {
+
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
@@ -1,9 +1,13 @@
 package com.dnd12th_4.pickitalki.domain.channel;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import java.util.UUID;
 
 public interface ChannelMemberRepository  extends JpaRepository<ChannelMember,Long> {
+
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
@@ -1,0 +1,6 @@
+package com.dnd12th_4.pickitalki.domain.channel;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelMemberRepository  extends JpaRepository<ChannelMember,Long> {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelRepository.java
@@ -1,0 +1,7 @@
+package com.dnd12th_4.pickitalki.domain.channel;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChannelRepository extends JpaRepository<Channel,Long> {
+
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelRepository.java
@@ -2,6 +2,11 @@ package com.dnd12th_4.pickitalki.domain.channel;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ChannelRepository extends JpaRepository<Channel,Long> {
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ChannelRepository extends JpaRepository<Channel,UUID> {
+
+    Optional<Channel> findByUuid(UUID uuid);
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
@@ -12,7 +12,6 @@ import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 
 @Getter
-@Setter
 @SuperBuilder
 @Entity
 @Table(name = "members")
@@ -48,4 +47,11 @@ public class Member extends BaseEntity {
         this.profileImageUrl = image;
     }
 
+    public void setNickName(String nickName) {
+        this.nickName = nickName;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
@@ -1,15 +1,15 @@
 package com.dnd12th_4.pickitalki.domain.member;
 
 import com.dnd12th_4.pickitalki.domain.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
+import org.apache.logging.log4j.util.Lazy;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @SuperBuilder
@@ -36,6 +36,9 @@ public class Member extends BaseEntity {
     @Column(nullable = true)
     private String refreshToken;
 
+    @OneToMany(mappedBy = "member",fetch = FetchType.LAZY)
+    private List<ChannelMember> channelMembers = new ArrayList<>();
+
     protected Member() {
         super();
 
@@ -54,4 +57,16 @@ public class Member extends BaseEntity {
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public void makeChannelMember(ChannelMember channelMember){
+        if(channelMembers==null){
+            channelMembers = new ArrayList<>();
+        }
+
+        if (channelMember != null && !channelMembers.contains(channelMember)) {
+            channelMembers.add(channelMember);
+            channelMember.makeMember(this);
+        }
+    }
+
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/question/QuestionRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/question/QuestionRepository.java
@@ -1,0 +1,15 @@
+package com.dnd12th_4.pickitalki.domain.question;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.UUID;
+
+public interface QuestionRepository extends JpaRepository<Question,Long> {
+
+    @Query("SELECT COUNT(q) FROM Question q WHERE q.channel.uuid = :channelUuid")
+    long countByChannelUuid(@Param("channelUuid") UUID channelUuid);
+
+
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/presentation/error/ErrorCode.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/presentation/error/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode implements ErrorCodeIfs{
     BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), 400,"잘못된 요청"),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(),500,"서버 에러"),
     NULL_POINT(HttpStatus.INTERNAL_SERVER_ERROR.value(),512,"Null Pointer" ),
+    DUPLICATED_MEMBER(HttpStatus.BAD_REQUEST.value(),499,"중복된 멤버")
     ;
 
 

--- a/src/main/java/com/dnd12th_4/pickitalki/presentation/exception/ApiException.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/presentation/exception/ApiException.java
@@ -20,7 +20,7 @@ public class ApiException extends RuntimeException implements ApiExceptionIfs{
     public ApiException(ErrorCodeIfs errorCodeIfs, String errorDescription) {
         super(errorCodeIfs.getDescription());
         this.errorCodeIfs = errorCodeIfs;
-        this.errorDescription=errorCodeIfs.getDescription();
+        this.errorDescription=errorDescription;
     }
 
     public ApiException(ErrorCodeIfs errorCodeIfs, Throwable tx) {

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -27,14 +27,12 @@ public class ChannelService {
 
         Channel channel = new Channel(channelName);
 
-        ChannelMember ChannelMemberEntity = getChannelMember();
+        ChannelMember ChannelMemberEntity = getChannelMember(Role.OWNER);
 
         ChannelMemberEntity.makeChannel(channel);
         ChannelMemberEntity.makeMember(member);
 
-        ChannelMember channelMember = channelMemberRepository.save(ChannelMemberEntity);
-
-        return channelMember;
+        return channelMemberRepository.save(ChannelMemberEntity);
 
     }
 
@@ -48,13 +46,40 @@ public class ChannelService {
         return channelMember.getChannel();
     }
 
+    @Transactional
+    public ChannelMember invited(Long memberId, UUID channelUuid) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "ChannelMember invided 53번째줄 에러"));
+        Channel channel = channelRepository.findByUuid(channelUuid)
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "ChannelMember invided 55번째줄 에러"));
 
-    private  ChannelMember getChannelMember() {
-        ChannelMember ChannelMemberEntity = ChannelMember.builder()
-                .role(Role.OWNER)
-                .build();
-        return ChannelMemberEntity;
+        validatedDuplicate(channel, member);
+
+        ChannelMember channelMemberEntity = getChannelMember(Role.MEMBER);
+
+        channelMemberEntity.makeMember(member);
+        channelMemberEntity.makeChannel(channel);
+
+        return channelMemberRepository.save(channelMemberEntity);
+
     }
+
+    private  void validatedDuplicate(Channel channel, Member member) {
+
+        channel.getChannelMembers().forEach(channelMember -> {
+            if (channelMember.getMember().getId().equals(member.getId())) {
+                throw new ApiException(ErrorCode.DUPLICATED_MEMBER,"validateDuplicate 71번째줄 에러 ");
+            }
+        });
+    }
+
+
+    private  ChannelMember getChannelMember(Role role) {
+        return ChannelMember.builder()
+                .role(role)
+                .build();
+    }
+
 
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -9,6 +9,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class ChannelService {
@@ -19,7 +21,7 @@ public class ChannelService {
 
 
     @Transactional
-    public Channel save(Long memberId, String channelName) {
+    public ChannelMember save(Long memberId, String channelName) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST,"Channel save 24번쭐 에러발생"));
 
@@ -30,12 +32,21 @@ public class ChannelService {
         ChannelMemberEntity.makeChannel(channel);
         ChannelMemberEntity.makeMember(member);
 
-        channelMemberRepository.save(ChannelMemberEntity);
+        ChannelMember channelMember = channelMemberRepository.save(ChannelMemberEntity);
 
-        return channel;
+        return channelMember;
 
     }
 
+    @Transactional
+    public Channel updateCodeName(Long channelMemberId, String codeName) {
+
+        ChannelMember channelMember = channelMemberRepository.findById(channelMemberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "ChannelMember updateCodeName 43번째 줄에서 에러 발생"));
+
+        channelMember.setMemberCodeName(codeName);
+        return channelMember.getChannel();
+    }
 
 
     private  ChannelMember getChannelMember() {
@@ -44,4 +55,6 @@ public class ChannelService {
                 .build();
         return ChannelMemberEntity;
     }
+
+
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -1,0 +1,47 @@
+package com.dnd12th_4.pickitalki.service.channel;
+
+import com.dnd12th_4.pickitalki.domain.channel.*;
+import com.dnd12th_4.pickitalki.domain.member.Member;
+import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
+import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
+import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChannelService {
+
+    private final ChannelRepository channelRepository;
+    private final MemberRepository memberRepository;
+    private final ChannelMemberRepository channelMemberRepository;
+
+
+    @Transactional
+    public Channel save(Long memberId, String channelName) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST,"Channel save 24번쭐 에러발생"));
+
+        Channel channel = new Channel(channelName);
+
+        ChannelMember ChannelMemberEntity = getChannelMember();
+
+        ChannelMemberEntity.makeChannel(channel);
+        ChannelMemberEntity.makeMember(member);
+
+        channelMemberRepository.save(ChannelMemberEntity);
+
+        return channel;
+
+    }
+
+
+
+    private  ChannelMember getChannelMember() {
+        ChannelMember ChannelMemberEntity = ChannelMember.builder()
+                .role(Role.OWNER)
+                .build();
+        return ChannelMemberEntity;
+    }
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -1,15 +1,22 @@
 package com.dnd12th_4.pickitalki.service.channel;
 
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.domain.channel.*;
 import com.dnd12th_4.pickitalki.domain.member.Member;
 import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
+import com.dnd12th_4.pickitalki.domain.question.QuestionRepository;
 import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
 import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,12 +25,13 @@ public class ChannelService {
     private final ChannelRepository channelRepository;
     private final MemberRepository memberRepository;
     private final ChannelMemberRepository channelMemberRepository;
+    private final QuestionRepository questionRepository;
 
 
     @Transactional
     public ChannelMember save(Long memberId, String channelName) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST,"Channel save 24번쭐 에러발생"));
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "Channel save 24번쭐 에러발생"));
 
         Channel channel = new Channel(channelName);
 
@@ -64,22 +72,61 @@ public class ChannelService {
 
     }
 
-    private  void validatedDuplicate(Channel channel, Member member) {
+    @Transactional
+    public List<ChannelShowAllResponse> myRooms(Long memberId, ChannelControllerEnums status) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "ChannelMember invided 71번째줄 에러"));
+
+        List<ChannelShowAllResponse> myRoomList = new ArrayList<>();
+
+        member.getChannelMembers().stream()
+                .filter(channelMember ->
+                        status == ChannelControllerEnums.SHOWALL ||
+                                (status == ChannelControllerEnums.INVITEDALL && channelMember.getRole() == Role.MEMBER) ||
+                                (status == ChannelControllerEnums.MADEALL && channelMember.getRole() == Role.OWNER)
+                )
+                .map(this::buildChannelShowAllResponse)
+                .forEach(myRoomList::add);
+
+        return myRoomList;
+
+    }
+
+    private ChannelShowAllResponse buildChannelShowAllResponse(ChannelMember channelMember) {
+
+        Channel channel = channelMember.getChannel();
+
+        String ownerName = channel.getChannelMembers().stream()
+                .filter(it -> it.getRole() == Role.OWNER && it.getChannel().equals(channel))
+                .findAny()
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "buildChannelShowAllResponse DB 튜플이 없습니다"))
+                .getMemberCodeName();
+
+        long signalCount = questionRepository.countByChannelUuid(channel.getUuid());
+
+        return ChannelShowAllResponse.builder()
+                .channelOwnerName(ownerName)
+                .channelRoomName(channel.getName())
+                .countPerson((long) channel.getChannelMembers().size())
+                .singalCount(signalCount)
+                .build();
+    }
+
+    private void validatedDuplicate(Channel channel, Member member) {
 
         channel.getChannelMembers().forEach(channelMember -> {
             if (channelMember.getMember().getId().equals(member.getId())) {
-                throw new ApiException(ErrorCode.DUPLICATED_MEMBER,"validateDuplicate 71번째줄 에러 ");
+                throw new ApiException(ErrorCode.DUPLICATED_MEMBER, "validateDuplicate 71번째줄 에러 ");
             }
         });
     }
 
-
-    private  ChannelMember getChannelMember(Role role) {
+    private ChannelMember getChannelMember(Role role) {
         return ChannelMember.builder()
                 .role(role)
                 .build();
     }
-
 
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/KaKaoSignUpService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/KaKaoSignUpService.java
@@ -39,12 +39,12 @@ public class KaKaoSignUpService {
     public Member saveUserEntity(Member member){
         return Optional.ofNullable(member)
                 .map(memberRepository::save)
-                .orElseThrow(()-> new ApiException(MemberErrorCode.INVALID_ARGUMENT));
+                .orElseThrow(()-> new ApiException(MemberErrorCode.INVALID_ARGUMENT,"Member saveUserEntity 42번째줄 에러"));
 
     }
 
     public Member findUser(String token){
         return memberRepository.findByRefreshToken(token)
-                .orElseThrow(() -> new ApiException(TokenErrorCode.INVALID_TOKEN));
+                .orElseThrow(() -> new ApiException(TokenErrorCode.INVALID_TOKEN,"Member findUser 48번째줄 에러"));
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
@@ -1,0 +1,27 @@
+package com.dnd12th_4.pickitalki.service.login;
+
+
+import com.dnd12th_4.pickitalki.domain.member.Member;
+import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
+import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
+import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public Member updateName(Long memberId, String name){
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "해당 member가 DB에 없습니다."));
+
+        member.setNickName(name);
+        return member;
+    }
+
+}


### PR DESCRIPTION
## What is this PR? :mag:
@Valid 어노테이션/ ApiException 예외 설명 상세 / 로그인 및 회원가입 직후 방 가입 하는 api기능 만들었습니다
```
throw new ApiException(ErroCode.BAD_REQUEST,"무슨 무슨 함수에서 오류 발생");  과 같이 오류 위치 상세히 기록
```

회원가입 직후 방생성 or 방참여 기능이 있습니다. 
해당 부분을 ChannelController 에 구현했고 
member 과 channelMember 두 도맨인을 양방향 연관관계를 설정하여 domain을 살짝 손봤습니다.

양방향 연관관계를 한 이유는 
자신이 속한 모든 방들을 출력 or 자신이 초대받은 방들을 출력하는 api를 개발하려면 양방향 연관관계가 편할거 같다고 생각했습니다.


### [추가]
전체방/ 초대된 방/ 만든 방 api 기능도 만들었습니다.

다만 여기서 문제점이 N+1문제가 발생되어 추후 리팩토링 진행하겠습니다.

## Changes :memo:
member 와 channelMember 관련된 양방향 연관관계를 설정했습니다.
```
public void makeChannelMember(ChannelMember channelMember){
        if(channelMembers==null){
            channelMembers = new ArrayList<>();
        }

        if (channelMember != null && !channelMembers.contains(channelMember)) {
            channelMembers.add(channelMember);
            channelMember.makeMember(this);
        }
    }


 public void makeMember(Member member){
        if(member==null)return;

        if(this.member!=member){
            this.member=member;
            member.makeChannelMember(this);
        }
    }

```
위의 코드들 처럼 저는 domain 양쪽 다 객체를 넣어주는걸 선호하여 위와 같이 코드를 구성했습니다.
또한 UUID관련 DB는 - << 빼기 기호가 없이 저장이 됩니다.
그래서 RequestParam 형태로 String 형태로 가져오게되면
숫자-숫자-숫자-숫자 형태로 변환해줘야 됩니다.
그래서 converter 함수도 따로 구현했습니다.

## Screenshot :camera:
![image](https://github.com/user-attachments/assets/4083002b-5912-4e8d-9576-42e8d844a3f8)
