### PR TITLE
채널의 생성,초대,조회 기능 구현

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/common/resolver/MemberIdResolver.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/resolver/MemberIdResolver.java
@@ -20,7 +20,7 @@ public class MemberIdResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(MemberId.class) &&
-                parameter.getParameterType().equals(String.class);
+                parameter.getParameterType().equals(Long.class);
     }
 
     @Override

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -46,7 +46,7 @@ public class ChannelController {
     @PatchMapping("/{channelId}/codeName")
     public Api<MemberCodeNameResponse> updateMemberCodeName(
             @MemberId Long memberId,
-            @PathVariable String channelId,
+            @PathVariable("channelId") String channelId,
             @RequestParam("codeName") @Valid String codeName
     ) {
         MemberCodeNameResponse memberCodeNameResponse = channelService.updateCodeName(memberId, channelId, codeName);

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -76,6 +76,15 @@ public class ChannelController {
     }
 
     @GetMapping
+    public Api<ChannelShowAllResponse> findChannel(
+            @MemberId Long memberId,
+            @RequestParam(value = "channelName") String channelName
+    ) {
+        ChannelShowAllResponse channelShowAllResponses = channelService.findChannelByChannelName(memberId, channelName);
+        return Api.OK(channelShowAllResponses);
+    }
+
+    @GetMapping("/all")
     public Api<List<ChannelShowAllResponse>> findAllChannels(
             @MemberId Long memberId
     ) {

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -43,7 +43,7 @@ public class ChannelController {
                 .body(channelResponse);
     }
 
-    @PatchMapping("/{channelId}/code-name")
+    @PatchMapping("/{channelId}/codeName")
     public Api<MemberCodeNameResponse> updateMemberCodeName(
             @MemberId Long memberId,
             @PathVariable String channelId,
@@ -74,7 +74,7 @@ public class ChannelController {
         return Api.OK(channelJoinResponse);
     }
 
-    @GetMapping
+    @GetMapping("/invited")
     public Api<List<ChannelShowAllResponse>> findAllInvitedChannels(
             @MemberId Long memberId
     ) {
@@ -92,8 +92,8 @@ public class ChannelController {
         return Api.OK(channelShowAllResponses);
     }
 
-    @GetMapping("/room/all")
-    public Api<List<ChannelShowAllResponse>> findAllJoinedChannels(
+    @GetMapping
+    public Api<List<ChannelShowAllResponse>> findAllChannels(
             @MemberId Long memberId
     ) {
         List<ChannelShowAllResponse> channelShowAllResponses = channelService.findAllMyChannels(memberId, ChannelControllerEnums.SHOWALL);

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -74,29 +74,29 @@ public class ChannelController {
         return Api.OK(channelJoinResponse);
     }
 
-    @GetMapping("/invited/room/all")
-    public Api<List<ChannelShowAllResponse>> invitedRoomAll(
+    @GetMapping
+    public Api<List<ChannelShowAllResponse>> findAllInvitedChannels(
             @MemberId Long memberId
     ) {
-        List<ChannelShowAllResponse> channelShowAllResponses = channelService.myRooms(memberId, ChannelControllerEnums.INVITEDALL);
+        List<ChannelShowAllResponse> channelShowAllResponses = channelService.findAllMyChannels(memberId, ChannelControllerEnums.INVITEDALL);
 
         return Api.OK(channelShowAllResponses);
     }
 
     @GetMapping("/make/room/all")
-    public Api<List<ChannelShowAllResponse>> makeRoomAll(
+    public Api<List<ChannelShowAllResponse>> findAllOwnChannels(
             @MemberId Long memberId
     ) {
-        List<ChannelShowAllResponse> channelShowAllResponses = channelService.myRooms(memberId, ChannelControllerEnums.MADEALL);
+        List<ChannelShowAllResponse> channelShowAllResponses = channelService.findAllMyChannels(memberId, ChannelControllerEnums.MADEALL);
 
         return Api.OK(channelShowAllResponses);
     }
 
     @GetMapping("/room/all")
-    public Api<List<ChannelShowAllResponse>> roomAll(
+    public Api<List<ChannelShowAllResponse>> findAllJoinedChannels(
             @MemberId Long memberId
     ) {
-        List<ChannelShowAllResponse> channelShowAllResponses = channelService.myRooms(memberId, ChannelControllerEnums.SHOWALL);
+        List<ChannelShowAllResponse> channelShowAllResponses = channelService.findAllMyChannels(memberId, ChannelControllerEnums.SHOWALL);
         return Api.OK(channelShowAllResponses);
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -35,9 +35,10 @@ public class ChannelController {
     @PostMapping
     public ResponseEntity<ChannelResponse> makeChannel(
             @MemberId Long memberId,
-            @RequestParam("channelName") @Valid String channelName
+            @RequestParam("channelName") @Valid String channelName,
+            @RequestParam(value = "codeName", required = false) String codeName
     ) {
-        ChannelResponse channelResponse = channelService.save(memberId, channelName);
+        ChannelResponse channelResponse = channelService.save(memberId, channelName, codeName);
 
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(channelResponse);

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -75,16 +75,15 @@ public class ChannelController {
         return Api.OK(channelJoinResponse);
     }
 
-    @GetMapping("/invited")
-    public Api<List<ChannelShowAllResponse>> findAllInvitedChannels(
+    @GetMapping
+    public Api<List<ChannelShowAllResponse>> findAllChannels(
             @MemberId Long memberId
     ) {
-        List<ChannelShowAllResponse> channelShowAllResponses = channelService.findAllMyChannels(memberId, ChannelControllerEnums.INVITEDALL);
-
+        List<ChannelShowAllResponse> channelShowAllResponses = channelService.findAllMyChannels(memberId, ChannelControllerEnums.SHOWALL);
         return Api.OK(channelShowAllResponses);
     }
 
-    @GetMapping("/make/room/all")
+    @GetMapping("/own")
     public Api<List<ChannelShowAllResponse>> findAllOwnChannels(
             @MemberId Long memberId
     ) {
@@ -93,11 +92,12 @@ public class ChannelController {
         return Api.OK(channelShowAllResponses);
     }
 
-    @GetMapping
-    public Api<List<ChannelShowAllResponse>> findAllChannels(
+    @GetMapping("/invited")
+    public Api<List<ChannelShowAllResponse>> findAllInvitedChannels(
             @MemberId Long memberId
     ) {
-        List<ChannelShowAllResponse> channelShowAllResponses = channelService.findAllMyChannels(memberId, ChannelControllerEnums.SHOWALL);
+        List<ChannelShowAllResponse> channelShowAllResponses = channelService.findAllMyChannels(memberId, ChannelControllerEnums.INVITEDALL);
+
         return Api.OK(channelShowAllResponses);
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -1,13 +1,12 @@
 package com.dnd12th_4.pickitalki.controller.channel;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
-import com.dnd12th_4.pickitalki.common.converter.UUIDConverter;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
-import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelJoinResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.InviteCodeDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.MemberCodeNameResponse;
-import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.channel.ChannelService;
 import jakarta.validation.Valid;
@@ -18,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,7 +33,7 @@ public class ChannelController {
     private final ChannelService channelService;
 
     @PostMapping
-    public ResponseEntity<ChannelResponse> makeRoom(
+    public ResponseEntity<ChannelResponse> makeChannel(
             @MemberId Long memberId,
             @RequestParam("channelName") @Valid String channelName
     ) {
@@ -54,16 +54,24 @@ public class ChannelController {
         return Api.OK(memberCodeNameResponse);
     }
 
-    @PostMapping("/invited/room")
-    public Api<ChannelMemberResponse> invitedRoom(
+    @GetMapping("/inviteCode")
+    public ResponseEntity<InviteCodeDto> getChannelInviteCode(
             @MemberId Long memberId,
-            @RequestParam("channelUuid") @Valid String channelUuid
+            @RequestParam("channelName") @Valid String channelName
     ) {
+        String inviteCode = channelService.findInviteCode(memberId, channelName);
+        return ResponseEntity.ok(new InviteCodeDto(inviteCode));
+    }
 
-        ChannelMember channelMember = channelService.invited(memberId, UUIDConverter.toUUID(channelUuid));
-        ChannelMemberResponse channelMemberResponse = new ChannelMemberResponse(channelMember.getId());
+    @PostMapping("/join")
+    public Api<ChannelJoinResponse> joinMemberToChannel(
+            @MemberId Long memberId,
+            @RequestBody InviteCodeDto joinRequest,
+            @RequestParam(value = "codeName", required = false) String codeName
+    ) {
+        ChannelJoinResponse channelJoinResponse = channelService.joinMember(memberId, joinRequest.inviteCode(), codeName);
 
-        return Api.OK(channelMemberResponse);
+        return Api.OK(channelJoinResponse);
     }
 
     @GetMapping("/invited/room/all")

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -6,7 +6,7 @@ import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
-import com.dnd12th_4.pickitalki.domain.channel.Channel;
+import com.dnd12th_4.pickitalki.controller.channel.dto.MemberCodeNameResponse;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.channel.ChannelService;
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,15 +43,15 @@ public class ChannelController {
                 .body(channelResponse);
     }
 
-    @PostMapping("/codename/{channelMemberId}")
-    public Api<ChannelResponse> codeName(
-            @PathVariable Long channelMemberId,
+    @PatchMapping("/{channelId}/code-name")
+    public Api<MemberCodeNameResponse> updateMemberCodeName(
+            @MemberId Long memberId,
+            @PathVariable String channelId,
             @RequestParam("codeName") @Valid String codeName
     ) {
-        Channel channel = channelService.updateCodeName(channelMemberId, codeName);
-        ChannelResponse channelResponse = new ChannelResponse(channel.getUuid().toString());
+        MemberCodeNameResponse memberCodeNameResponse = channelService.updateCodeName(memberId, channelId, codeName);
 
-        return Api.OK(channelResponse);
+        return Api.OK(memberCodeNameResponse);
     }
 
     @PostMapping("/invited/room")

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -12,7 +12,14 @@ import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.channel.ChannelService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
@@ -24,15 +31,15 @@ public class ChannelController {
 
     private final ChannelService channelService;
 
-    @PostMapping("/make/room")
-    public Api<ChannelMemberResponse> makeRoom(
+    @PostMapping
+    public ResponseEntity<ChannelResponse> makeRoom(
             @MemberId Long memberId,
             @RequestParam("channelName") @Valid String channelName
     ) {
-        ChannelMember channelMember = channelService.save(memberId, channelName);
-        ChannelMemberResponse channelMemberResponse = new ChannelMemberResponse(channelMember.getId());
+        ChannelResponse channelResponse = channelService.save(memberId, channelName);
 
-        return Api.OK(channelMemberResponse);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(channelResponse);
     }
 
     @PostMapping("/codename/{channelMemberId}")
@@ -41,7 +48,7 @@ public class ChannelController {
             @RequestParam("codeName") @Valid String codeName
     ) {
         Channel channel = channelService.updateCodeName(channelMemberId, codeName);
-        ChannelResponse channelResponse = new ChannelResponse(channel.getUuid());
+        ChannelResponse channelResponse = new ChannelResponse(channel.getUuid().toString());
 
         return Api.OK(channelResponse);
     }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelJoinResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelJoinResponse.java
@@ -1,4 +1,4 @@
 package com.dnd12th_4.pickitalki.controller.channel.dto;
 
-public record ChannelJoinResponse(String channelId, String codeName) {
+public record ChannelJoinResponse(String channelId, String channelName,String codeName) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelJoinResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelJoinResponse.java
@@ -1,0 +1,4 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto;
+
+public record ChannelJoinResponse(String channelId, String codeName) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelResponse.java
@@ -2,5 +2,5 @@ package com.dnd12th_4.pickitalki.controller.channel.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record ChannelResponse(@NotBlank String uuid) {
+public record ChannelResponse(@NotBlank String channelId, String channelName, String inviteCode) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelResponse.java
@@ -1,15 +1,4 @@
 package com.dnd12th_4.pickitalki.controller.channel.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import java.util.UUID;
-
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class ChannelResponse {
-
-    private UUID chanelUuid;
+public record ChannelResponse(String uuid) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelResponse.java
@@ -1,4 +1,6 @@
 package com.dnd12th_4.pickitalki.controller.channel.dto;
 
-public record ChannelResponse(String uuid) {
+import jakarta.validation.constraints.NotBlank;
+
+public record ChannelResponse(@NotBlank String uuid) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/InviteCodeDto.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/InviteCodeDto.java
@@ -2,5 +2,5 @@ package com.dnd12th_4.pickitalki.controller.channel.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record MemberCodeNameResponse(@NotBlank String codeName) {
+public record InviteCodeDto(@NotBlank String inviteCode) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/MemberCodeNameResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/MemberCodeNameResponse.java
@@ -1,0 +1,4 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto;
+
+public record MemberCodeNameResponse(String codeName) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/BaseEntity.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/BaseEntity.java
@@ -27,7 +27,7 @@ public abstract class BaseEntity {
     @Column(name = "updated_at")
     protected LocalDateTime updatedAt;
 
-    @Column(nullable = false)
+    @Column(nullable = false, name = "is_deleted")
     protected boolean isDeleted = false;
 
     public void softDelete() {

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -72,4 +72,12 @@ public class Channel extends BaseEntity implements Persistable<String> {
             throw new IllegalArgumentException("이미 해당 채널에 존재하는 회원입니다.");
         }
     }
+
+    public ChannelMember findChannelMemberById(Long memberId) {
+        return channelMembers.stream().filter(channelMember -> channelMember.isSameMember(memberId))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 채널에 존재하지 않습니다."));
+
+    }
+
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -2,7 +2,12 @@ package com.dnd12th_4.pickitalki.domain.channel;
 
 import com.dnd12th_4.pickitalki.domain.BaseEntity;
 import com.dnd12th_4.pickitalki.domain.question.Question;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.domain.Persistable;
@@ -26,7 +31,7 @@ public class Channel extends BaseEntity implements Persistable<String> {
     @Column(nullable = false, length = 10)
     private String name;
 
-    @OneToMany(mappedBy = "channel")
+    @OneToMany(mappedBy = "channel", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
     private List<ChannelMember> channelMembers = new ArrayList<>();
 
     @OneToMany(mappedBy = "channel")
@@ -34,14 +39,13 @@ public class Channel extends BaseEntity implements Persistable<String> {
 
     protected Channel() {}
 
-    public Channel(String name) {
-        this.uuid = UUID.randomUUID();
-        this.name = name;
-    }
-
     public Channel(UUID uuid, String name) {
         this.uuid = uuid;
         this.name = name;
+    }
+
+    public Channel(String name) {
+        this(UUID.randomUUID(), name);
     }
 
     @Override
@@ -54,14 +58,18 @@ public class Channel extends BaseEntity implements Persistable<String> {
         return uuid.toString();
     }
 
-    public void makeChannelMember(ChannelMember channelMember){
-        if(channelMembers==null){
-            channelMembers = new ArrayList<>();
+    public void joinChannelMember(ChannelMember channelMember){
+        validateChannelMember(channelMember);
+        channelMembers.add(channelMember);
+    }
+
+    private void validateChannelMember(ChannelMember channelMember) {
+        if (isNull(channelMember)) {
+            throw new IllegalArgumentException("채널의 회원이 존재하지 않습니다.");
         }
 
-        if(channelMember!=null && !channelMembers.contains(channelMember)){
-            channelMembers.add(channelMember);
-            channelMember.makeChannel(this);
+        if (channelMembers.contains(channelMember)) {
+            throw new IllegalArgumentException("이미 해당 채널에 존재하는 회원입니다.");
         }
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -2,9 +2,9 @@ package com.dnd12th_4.pickitalki.domain.channel;
 
 import com.dnd12th_4.pickitalki.domain.BaseEntity;
 import com.dnd12th_4.pickitalki.domain.question.Question;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
@@ -16,6 +16,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import static jakarta.persistence.CascadeType.MERGE;
+import static jakarta.persistence.CascadeType.PERSIST;
 import static java.util.Objects.isNull;
 
 @Getter
@@ -31,10 +33,10 @@ public class Channel extends BaseEntity implements Persistable<String> {
     @Column(nullable = false, length = 10)
     private String name;
 
-    @OneToMany(mappedBy = "channel", cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @OneToMany(mappedBy = "channel", cascade = {PERSIST, MERGE}, fetch = FetchType.LAZY)
     private List<ChannelMember> channelMembers = new ArrayList<>();
 
-    @OneToMany(mappedBy = "channel")
+    @OneToMany(mappedBy = "channel", fetch = FetchType.LAZY)
     private List<Question> questions = new ArrayList<>();
 
     protected Channel() {}
@@ -77,7 +79,6 @@ public class Channel extends BaseEntity implements Persistable<String> {
         return channelMembers.stream().filter(channelMember -> channelMember.isSameMember(memberId))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 채널에 존재하지 않습니다."));
-
     }
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -3,10 +3,23 @@ package com.dnd12th_4.pickitalki.domain.channel;
 
 import com.dnd12th_4.pickitalki.domain.BaseEntity;
 import com.dnd12th_4.pickitalki.domain.member.Member;
-import jakarta.persistence.*;
-import lombok.Builder;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
+
+import java.util.Objects;
+
+import static java.util.Objects.hash;
+import static java.util.Objects.isNull;
 
 @Getter
 @Table(name = "channel_members")
@@ -18,11 +31,11 @@ public class ChannelMember extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @ManyToOne
     @JoinColumn(name = "channel_uuid", nullable = false)
     private Channel channel;
 
-    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @ManyToOne
     @JoinColumn(name = "member_id" ,nullable = false)
     private Member member;
 
@@ -37,33 +50,38 @@ public class ChannelMember extends BaseEntity {
     protected ChannelMember() {
     }
 
-    public ChannelMember(Long id, Channel channel, Member member, Role role) {
-        this.id = id;
+    public ChannelMember(Channel channel, Member member, Role role) {
+        validateChannel(channel);
         this.channel = channel;
         this.member = member;
         this.role = role;
+    }
+
+    private void validateChannel(Channel channel) {
+        if (isNull(channel)) {
+            throw new IllegalArgumentException("참여할 채널이 존재하지 않습니다.");
+        }
+
+        if (Objects.equals(this.channel, channel)) {
+            throw new IllegalArgumentException("이미 해당 채널에 참여한 회원입니다.");
+        }
     }
 
     public void setMemberCodeName(String memberCodeName) {
         this.memberCodeName = memberCodeName;
     }
 
-    public void makeMember(Member member){
-        if(member==null)return;
-
-        if(this.member!=member){
-            this.member=member;
-            member.makeChannelMember(this);
-        }
+    @Override
+    public int hashCode() {
+        return hash(id);
     }
 
-    public void makeChannel(Channel channel){
-        if(channel ==null)return;
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
 
-        if(this.channel!= channel){
-            this.channel = channel;
-            channel.makeChannelMember(this);
-        }
+        ChannelMember other = (ChannelMember) obj;
+        return Objects.equals(id, other.id);
     }
-
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -17,6 +17,8 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Objects;
 
 import static java.util.Objects.hash;
@@ -50,11 +52,16 @@ public class ChannelMember extends BaseEntity {
     protected ChannelMember() {
     }
 
-    public ChannelMember(Channel channel, Member member, Role role) {
+    public ChannelMember(Channel channel, Member member, String memberCodeName, Role role) {
         validateChannel(channel);
         this.channel = channel;
         this.member = member;
+        this.memberCodeName = memberCodeName;
         this.role = role;
+    }
+
+    public ChannelMember(Channel channel, Member member, Role role) {
+        this(channel, member, null, role);
     }
 
     private void validateChannel(Channel channel) {
@@ -73,6 +80,12 @@ public class ChannelMember extends BaseEntity {
 
     public boolean isSameMember(Long memberId) {
         return Objects.equals(memberId, this.member.getId());
+    }
+
+    public String getInviteCode() {
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(this.channel.getUuid().toString().getBytes(StandardCharsets.UTF_8));
     }
 
     @Override

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,11 +32,11 @@ public class ChannelMember extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "channel_uuid", nullable = false)
     private Channel channel;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id" ,nullable = false)
     private Member member;
 
@@ -45,7 +46,6 @@ public class ChannelMember extends BaseEntity {
     @Column(columnDefinition = "varchar(50)", nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
-
 
     protected ChannelMember() {
     }
@@ -69,6 +69,10 @@ public class ChannelMember extends BaseEntity {
 
     public void setMemberCodeName(String memberCodeName) {
         this.memberCodeName = memberCodeName;
+    }
+
+    public boolean isSameMember(Long memberId) {
+        return Objects.equals(memberId, this.member.getId());
     }
 
     @Override

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
@@ -1,12 +1,9 @@
 package com.dnd12th_4.pickitalki.domain.channel;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
-import java.util.UUID;
-
+@Repository
 public interface ChannelMemberRepository  extends JpaRepository<ChannelMember,Long> {
 
 

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelRepository.java
@@ -11,4 +11,6 @@ public interface ChannelRepository extends JpaRepository<Channel,UUID> {
 
     Optional<Channel> findByUuid(UUID uuid);
 
+    Optional<Channel> findByName(String name);
+
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelRepository.java
@@ -1,10 +1,12 @@
 package com.dnd12th_4.pickitalki.domain.channel;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 import java.util.UUID;
 
+@Repository
 public interface ChannelRepository extends JpaRepository<Channel,UUID> {
 
     Optional<Channel> findByUuid(UUID uuid);

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
@@ -2,11 +2,16 @@ package com.dnd12th_4.pickitalki.domain.member;
 
 import com.dnd12th_4.pickitalki.domain.BaseEntity;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.experimental.SuperBuilder;
-import org.apache.logging.log4j.util.Lazy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -58,15 +63,15 @@ public class Member extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
-    public void makeChannelMember(ChannelMember channelMember){
-        if(channelMembers==null){
-            channelMembers = new ArrayList<>();
-        }
-
-        if (channelMember != null && !channelMembers.contains(channelMember)) {
-            channelMembers.add(channelMember);
-            channelMember.makeMember(this);
-        }
-    }
+//    public void makeChannelMember(ChannelMember channelMember){
+//        if(channelMembers==null){
+//            channelMembers = new ArrayList<>();
+//        }
+//
+//        if (channelMember != null && !channelMembers.contains(channelMember)) {
+//            channelMembers.add(channelMember);
+//            channelMember.makeMember(this);
+//        }
+//    }
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
@@ -63,15 +63,4 @@ public class Member extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
-//    public void makeChannelMember(ChannelMember channelMember){
-//        if(channelMembers==null){
-//            channelMembers = new ArrayList<>();
-//        }
-//
-//        if (channelMember != null && !channelMembers.contains(channelMember)) {
-//            channelMembers.add(channelMember);
-//            channelMember.makeMember(this);
-//        }
-//    }
-
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/member/MemberRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/member/MemberRepository.java
@@ -1,9 +1,11 @@
 package com.dnd12th_4.pickitalki.domain.member;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByKakaoId(Long kakaoId);
 

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -38,12 +38,18 @@ public class ChannelService {
 
 
     @Transactional
-    public ChannelResponse save(Long memberId, String channelName) {
+    public ChannelResponse save(Long memberId, String channelName, String codeName) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "존재하지 않는 회원입니다."));
 
         Channel channel = new Channel(channelName);
-        ChannelMember channelMember = new ChannelMember(channel, member, Role.OWNER);
+        ChannelMember channelMember;
+        if (isBlank(codeName)) {
+            channelMember = new ChannelMember(channel, member, member.getNickName(), Role.OWNER);
+        } else {
+            channelMember = new ChannelMember(channel, member, codeName, Role.OWNER);
+        }
+
         channel.joinChannelMember(channelMember);
         channel = channelRepository.save(channel);
 

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -89,12 +89,11 @@ public class ChannelService {
     }
 
     @Transactional
-    public List<ChannelShowAllResponse> myRooms(Long memberId, ChannelControllerEnums status) {
-
+    public List<ChannelShowAllResponse> findAllMyChannels(Long memberId, ChannelControllerEnums status) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "ChannelMember invided 71번째줄 에러"));
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "존재하지 않는 회원입니다. 참여한 채널들을 조회할 수 없습니다."));
 
-        List<ChannelShowAllResponse> myRoomList = new ArrayList<>();
+        List<ChannelShowAllResponse> myChannels = new ArrayList<>();
 
         member.getChannelMembers().stream()
                 .filter(channelMember ->
@@ -103,10 +102,9 @@ public class ChannelService {
                                 (status == ChannelControllerEnums.MADEALL && channelMember.getRole() == Role.OWNER)
                 )
                 .map(this::buildChannelShowAllResponse)
-                .forEach(myRoomList::add);
+                .forEach(myChannels::add);
 
-        return myRoomList;
-
+        return myChannels;
     }
 
     private ChannelShowAllResponse buildChannelShowAllResponse(ChannelMember channelMember) {
@@ -132,7 +130,7 @@ public class ChannelService {
 
     public String findInviteCode(Long memberId, String channelName) {
         Channel channel = channelRepository.findByName(channelName)
-                .orElseThrow(() -> new IllegalArgumentException("해당 이름의 채널을 찾을 수 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 이름의 채널을 찾을 수 없습니다. 초대코드를 응답할 수 없습니다."));
 
         ChannelMember channelMember = channel.findChannelMemberById(memberId);
         return channelMember.getInviteCode();

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -43,10 +43,11 @@ public class ChannelService {
                 .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "존재하지 않는 회원입니다."));
 
         Channel channel = new Channel(channelName);
-        channel.joinChannelMember(new ChannelMember(channel, member, Role.OWNER));
+        ChannelMember channelMember = new ChannelMember(channel, member, Role.OWNER);
+        channel.joinChannelMember(channelMember);
         channel = channelRepository.save(channel);
 
-        return new ChannelResponse(channel.getUuid().toString());
+        return new ChannelResponse(channel.getUuid().toString(), channelName, channelMember.getInviteCode());
     }
 
     @Transactional
@@ -79,7 +80,7 @@ public class ChannelService {
         channel.joinChannelMember(channelMember);
         channelMember = channelMemberRepository.save(channelMember);
 
-        return new ChannelJoinResponse(channel.getId(), channelMember.getMemberCodeName());
+        return new ChannelJoinResponse(channel.getId(), channel.getName(),channelMember.getMemberCodeName());
     }
 
     private UUID getUuidFromInviteCode(String inviteCode) {

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -142,4 +142,25 @@ public class ChannelService {
         ChannelMember channelMember = channel.findChannelMemberById(memberId);
         return channelMember.getInviteCode();
     }
+
+    public ChannelShowAllResponse findChannelByChannelName(Long memberId, String channelName) {
+        Channel channel = channelRepository.findByName(channelName)
+                .orElseThrow(() -> new IllegalArgumentException("해당 이름의 채널을 찾을 수 없습니다. 채널정보를 응답할 수 없습니다."));
+        ChannelMember channelMember = channel.findChannelMemberById(memberId);
+
+        String ownerName = channel.getChannelMembers().stream()
+                .filter(it -> it.getRole() == Role.OWNER && it.getChannel().equals(channel))
+                .findAny()
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "해당 채널의 주인을 찾을 수 없습니다."))
+                .getMemberCodeName();
+
+        long signalCount = questionRepository.countByChannelUuid(channel.getUuid());
+
+        return ChannelShowAllResponse.builder()
+                .channelOwnerName(ownerName)
+                .channelRoomName(channel.getName())
+                .countPerson((long) channel.getChannelMembers().size())
+                .singalCount(signalCount)
+                .build();
+    }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -3,6 +3,7 @@ package com.dnd12th_4.pickitalki.service.channel;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.MemberCodeNameResponse;
 import com.dnd12th_4.pickitalki.domain.channel.Channel;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMemberRepository;
@@ -44,13 +45,14 @@ public class ChannelService {
     }
 
     @Transactional
-    public Channel updateCodeName(Long channelMemberId, String codeName) {
+    public MemberCodeNameResponse updateCodeName(Long memberId, String channelId, String codeName) {
+        Channel channel = channelRepository.findByUuid(UUID.fromString(channelId))
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채널입니다. 코드네임을 변경할 수 없습니다."));
 
-        ChannelMember channelMember = channelMemberRepository.findById(channelMemberId)
-                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "ChannelMember updateCodeName 43번째 줄에서 에러 발생"));
-
+        ChannelMember channelMember = channel.findChannelMemberById(memberId);
         channelMember.setMemberCodeName(codeName);
-        return channelMember.getChannel();
+
+        return new MemberCodeNameResponse(codeName);
     }
 
     @Transactional

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -1,8 +1,13 @@
 package com.dnd12th_4.pickitalki.service.channel;
 
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
-import com.dnd12th_4.pickitalki.domain.channel.*;
+import com.dnd12th_4.pickitalki.domain.channel.Channel;
+import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
+import com.dnd12th_4.pickitalki.domain.channel.ChannelMemberRepository;
+import com.dnd12th_4.pickitalki.domain.channel.ChannelRepository;
+import com.dnd12th_4.pickitalki.domain.channel.Role;
 import com.dnd12th_4.pickitalki.domain.member.Member;
 import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
 import com.dnd12th_4.pickitalki.domain.question.QuestionRepository;
@@ -14,9 +19,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,19 +32,15 @@ public class ChannelService {
 
 
     @Transactional
-    public ChannelMember save(Long memberId, String channelName) {
+    public ChannelResponse save(Long memberId, String channelName) {
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "Channel save 24번쭐 에러발생"));
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "존재하지 않는 회원입니다."));
 
         Channel channel = new Channel(channelName);
+        channel.joinChannelMember(new ChannelMember(channel, member, Role.OWNER));
 
-        ChannelMember ChannelMemberEntity = getChannelMember(Role.OWNER);
-
-        ChannelMemberEntity.makeChannel(channel);
-        ChannelMemberEntity.makeMember(member);
-
-        return channelMemberRepository.save(ChannelMemberEntity);
-
+        channel = channelRepository.save(channel);
+        return new ChannelResponse(channel.getUuid().toString());
     }
 
     @Transactional
@@ -65,8 +64,8 @@ public class ChannelService {
 
         ChannelMember channelMemberEntity = getChannelMember(Role.MEMBER);
 
-        channelMemberEntity.makeMember(member);
-        channelMemberEntity.makeChannel(channel);
+//        channelMemberEntity.makeMember(member);
+//        channelMemberEntity.joinChannel(channel);
 
         return channelMemberRepository.save(channelMemberEntity);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:20000/pickitalki?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
+    url: jdbc:mysql://localhost:20000/pickitalki?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
     username: root
     password: root
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,5 @@
 
-CREATE TABLE if not exists `pickitalki`.members (
+create TABLE if not exists `pickitalki`.members (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     kakao_id BIGINT UNIQUE NOT NULL,
     email VARCHAR(100) UNIQUE,
@@ -7,25 +7,28 @@ CREATE TABLE if not exists `pickitalki`.members (
     profile_image_url TEXT NULL,
     refresh_token TEXT NULL,
     created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    boolean is_deleted DEFAULT FALSE
 );
 
-CREATE TABLE if not exists `pickitalki`.channels (
+create TABLE if not exists `pickitalki`.channels (
     uuid BINARY(16) PRIMARY KEY,
     name VARCHAR(30) NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    boolean is_deleted DEFAULT FALSE
 );
 
-CREATE TABLE if not exists `pickitalki`.channel_members (
+create TABLE if not exists `pickitalki`.channel_members (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     channel_uuid BINARY(16) NOT NULL,
     member_id VARCHAR(30) NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    boolean is_deleted DEFAULT FALSE,
     FOREIGN KEY (channel_uuid) REFERENCES channels(uuid),
     FOREIGN KEY (member_id) REFERENCES members(id)
 );
 
-CREATE TABLE if not exists `pickitalki`.questions (
+create TABLE if not exists `pickitalki`.questions (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     channel_uuid BINARY(16) NOT NULL,
     author_id VARCHAR(30) NOT NULL,
@@ -33,11 +36,12 @@ CREATE TABLE if not exists `pickitalki`.questions (
     is_anonymous BOOLEAN NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(30),
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    boolean is_deleted DEFAULT FALSE,
     FOREIGN KEY (channel_uuid) REFERENCES channels(uuid),
     FOREIGN KEY (author_id) REFERENCES members(id)
 );
 
-CREATE TABLE if not exists `pickitalki`.answers (
+create TABLE if not exists `pickitalki`.answers (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     question_id BIGINT NOT NULL,
     member_id BIGINT NOT NULL,
@@ -45,6 +49,7 @@ CREATE TABLE if not exists `pickitalki`.answers (
     is_anonymous BOOLEAN NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(10),
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    boolean is_deleted DEFAULT FALSE,
     FOREIGN KEY (question_id) REFERENCES questions(id),
     FOREIGN KEY (member_id) REFERENCES members(id)
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -8,22 +8,21 @@ create TABLE if not exists `pickitalki`.members (
     refresh_token TEXT NULL,
     created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-    boolean is_deleted DEFAULT FALSE
+    is_deleted TINYINT(1) NOT NULL DEFAULT 0
 );
 
 create TABLE if not exists `pickitalki`.channels (
     uuid BINARY(16) PRIMARY KEY,
     name VARCHAR(30) NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    boolean is_deleted DEFAULT FALSE
+    is_deleted TINYINT(1) NOT NULL DEFAULT 0
 );
-
 create TABLE if not exists `pickitalki`.channel_members (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     channel_uuid BINARY(16) NOT NULL,
     member_id VARCHAR(30) NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    boolean is_deleted DEFAULT FALSE,
+    is_deleted TINYINT(1) NOT NULL DEFAULT 0,
     FOREIGN KEY (channel_uuid) REFERENCES channels(uuid),
     FOREIGN KEY (member_id) REFERENCES members(id)
 );
@@ -36,7 +35,7 @@ create TABLE if not exists `pickitalki`.questions (
     is_anonymous BOOLEAN NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(30),
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    boolean is_deleted DEFAULT FALSE,
+    is_deleted TINYINT(1) NOT NULL DEFAULT 0,
     FOREIGN KEY (channel_uuid) REFERENCES channels(uuid),
     FOREIGN KEY (author_id) REFERENCES members(id)
 );
@@ -49,7 +48,7 @@ create TABLE if not exists `pickitalki`.answers (
     is_anonymous BOOLEAN NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(10),
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    boolean is_deleted DEFAULT FALSE,
+    is_deleted TINYINT(1) NOT NULL DEFAULT 0,
     FOREIGN KEY (question_id) REFERENCES questions(id),
     FOREIGN KEY (member_id) REFERENCES members(id)
 );


### PR DESCRIPTION
## What is this PR? :mag:
채널의 생성,초대,조회 기능 구현
## Changes :memo:
우선 도메인에서의 변화가 있습니다. channelMember쪽에 casacde타입을 선언하셨었는데
보통 채널멤버를 저장하기전에 채널과 멤버가 다 존재해야하기 때문에 이는 별로 의미가 없는 것 같고, 또 사실 이 경우에는 저장을 해줄 것이 아니라 존재하지 않는 채널이나 멤버에 대해 조인하려는 거기 때문에 예외를 던지는 상황이 맞지 않나싶습니다.
Channel쪽에서 멤버를 추가했을 때 영속성을 따르는 건 필요할 것 같아 여기에 casacade설정을 했습니다.

도메인의 메서드나 편의메소드에도 변화가 있습니다. 우선 저는 서비스로직에서 모든 걸 다하려고 하기보다 **도메인에 로직의 책임을 넘기는 게 좋다고 생각하기 떄문에 validate하는 것과 같은 비즈니스 로직을 도메인에 모아놓았습니다.**

channelMember에 채널에 참여하는 것과 연관되는 메서드를 둘거냐의 문제가 있는데, 저는 채널멤버는 일종의 중간엔티티로써 채널참여에 대한 책임을 가지고 있지는 않다고 생각합니다. **여기에 해당 메서드를 두어서 멤버가 없거나 채널이 없는 불안정한 상태는 channelMember를 생성하는 걸 가능하게하기보다, channelMember는 오직 채널과 멤버를 모두 가진 상태로만 생성이 가능하도록 생성자를 제한시켜놓는게 더 좋다 생각합니다.** 오히려 채널멤버의 채널이나 멤버를 변경하는 상황은 예외를 던져야 하는 상황이라 생각합니다. 이미 기존 채널에 참가해 있던 멤버가 다른 멤버로 수정되거나, 다른 채널로 옮겨가는 것과 같은 일은 우리 서비스에 없습니다. 채널에서 탈퇴하거나, 다시 재가입하거나는 가능하지만요

초대기능은 초대코드를 uuid로 바로 사용하는 것보다는 조금이라도 바꿔서 쓰는게 보안상 낫다고 생각했습니다. 그래서 uuid를 base64로 인코딩/디코딩하여 초대코드<->UUID로 변환해서 사용하도록 구현했습니다.

구현은 했지만 사실 테스트 코드가 없어서 변경감지나 쿼리가 의도한 대로 동작할 지 확신은 못하는 상태인 것 같네요;; 앞으로 최소한의 테스트코드를 추가하겠습니다.

## Screenshot :camera:

인터셉터 꺼두고, argumentResolver 아래처럼 1L 반환하도록 하고 테스트해보았더니 대부분 잘 되는 것 같습니다.

<img width="835" alt="image" src="https://github.com/user-attachments/assets/07f04544-93c3-4232-bfbb-ede929b79a21" />

![image](https://github.com/user-attachments/assets/d6e52522-fe5b-4ff0-b78c-e1251f6ff1b9)
![image](https://github.com/user-attachments/assets/95ed2846-5e3e-4777-a87f-05e499ade3f5)
![image](https://github.com/user-attachments/assets/99037ee3-eee1-4885-a322-1d1fd0792333)
