### PR TITLE
[refactor] : 에러 방지 구현 카카오서버

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/tool/HttpCreator.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/tool/HttpCreator.java
@@ -1,6 +1,8 @@
 package com.dnd12th_4.pickitalki.service.login.tool;
 
 import com.dnd12th_4.pickitalki.controller.login.dto.KakaoConfig;
+import com.dnd12th_4.pickitalki.presentation.error.TokenErrorCode;
+import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
@@ -35,16 +37,24 @@ public class HttpCreator {
 //    }
 
 
-    public ResponseEntity<Map> getResponseUserInfo(String accessToken){
-        System.out.println(accessToken);
+    public ResponseEntity<Map> getResponseUserInfo(String accessToken) {
+
         HttpHeaders headers = new HttpHeaders();
-        if(accessToken.startsWith("Bearer ")){
-            headers.set("Authorization",  accessToken);
-        } else{
+        if (accessToken.startsWith("Bearer ")) {
+            headers.set("Authorization", accessToken);
+        } else {
             headers.set("Authorization", "Bearer " + accessToken);
         }
 
         HttpEntity<String> request = new HttpEntity<>(headers);
-        return restTemplate.exchange(kakaoConfig.getUserInfoUrl(), HttpMethod.GET, request, Map.class);
+
+
+        try {
+            return restTemplate.exchange(kakaoConfig.getUserInfoUrl(), HttpMethod.GET, request, Map.class);
+
+        } catch (Exception e) {
+            throw new ApiException(TokenErrorCode.EXPIRED_TOKEN, "해당 카카오 토큰은 기간이 만료되엇습니다.");
+        }
+
     }
 }


### PR DESCRIPTION
## What is this PR? :mag:
카카오에서 받은 토큰을 전달하면 인터셉터를 거치면 안되게 설계했는데 거치는 오류를 해결했습니다.
이유는 현준님께서 주신 카카오 토큰이 기간이 만료된 토큰이였습니다. 

그래서 해당 토큰을 카카오서버로 전송하게 되면 만료된 토큰이라 오류를 발생시킨 다음 
우리 서버에 다시 보내게 됩니다. 
다시 보내게 되는 과정에서 해당 url을 저는 등록하지 않아서 인터셉트에 걸리게 되었던 겁니다.

[결론] => 카카오 서버로 토큰을 전달하는 코드를 try catch 구문으로 감싸서 예외처리를 한 결과
인터셉터를 거치치 않고 "해당 카카오 토큰은 기간이 만료되었습니다" 출력하게 변경
## Changes :memo:

## Screenshot :camera:
![image](https://github.com/user-attachments/assets/0a965953-27f3-4036-8104-10b7652bbf81)
![image](https://github.com/user-attachments/assets/a7c29ee5-517b-4dd6-9213-17a2c85cb652)


