### PR TITLE
리팩토링 및 로컬에서만 작동하고 배포시 문제 해결

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/common/config/CustomOpenApiConfig.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/config/CustomOpenApiConfig.java
@@ -1,0 +1,37 @@
+package com.dnd12th_4.pickitalki.common.config;
+
+import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.Arrays;
+
+@Component
+public class CustomOpenApiConfig implements OperationCustomizer {
+
+    @Override
+    public io.swagger.v3.oas.models.Operation customize(io.swagger.v3.oas.models.Operation operation, HandlerMethod handlerMethod) {
+        if (handlerMethod == null || handlerMethod.getMethodParameters() == null) {
+            return operation;
+        }
+
+        // 🔹 MethodParameter[] 배열을 Stream으로 변환하여 `@MemberId` 확인
+        boolean hasMemberId = Arrays.stream(handlerMethod.getMethodParameters())
+                .anyMatch(param -> param.hasParameterAnnotation(MemberId.class));
+
+        if (hasMemberId) {
+            // 🔹 @MemberId가 있는 매개변수를 Swagger 문서에서 제거
+            List<Parameter> filteredParameters = operation.getParameters().stream()
+                    .filter(param -> !param.getName().equalsIgnoreCase("memberId")) // Swagger에서 `memberId` 제거
+                    .collect(Collectors.toList());
+
+            operation.setParameters(filteredParameters);
+        }
+
+        return operation;
+    }
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/common/config/SwaggerConfig.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/config/SwaggerConfig.java
@@ -23,12 +23,12 @@ public class SwaggerConfig {
                                         .scheme("bearer")
                                         .bearerFormat("JWT"))
                         // 🔹 Refresh Token 쿠키 인증 설정
-                        .addSecuritySchemes("CookieAuth",
-                                new SecurityScheme()
-                                        .type(SecurityScheme.Type.APIKEY)  // 쿠키 기반 인증
-                                        .in(SecurityScheme.In.COOKIE)      // 쿠키에서 읽음
-                                        .name("refreshToken")              // 쿠키 이름
-                        ))
+//                        .addSecuritySchemes("CookieAuth",
+//                                new SecurityScheme()
+//                                        .type(SecurityScheme.Type.APIKEY)  // 쿠키 기반 인증
+//                                        .in(SecurityScheme.In.COOKIE)      // 쿠키에서 읽음
+//                                        .name("refreshToken")              // 쿠키 이름
+                        )
                 .addSecurityItem(new SecurityRequirement()
                         .addList("Bearer Authentication")  // Bearer 인증 적용
                         .addList("CookieAuth"));           // RefreshToken 인증 적용

--- a/src/main/java/com/dnd12th_4/pickitalki/common/config/WebConfig.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/config/WebConfig.java
@@ -43,6 +43,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+
         resolvers.add(memberIdResolver);
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/common/interceptor/JwtInterceptor.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/interceptor/JwtInterceptor.java
@@ -17,10 +17,12 @@ public class JwtInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
         String token = resolveToken(request);
 
         if (token != null) {
             try {
+
                 jwtProvider.validateToken(token);
 
             } catch (Exception e) {

--- a/src/main/java/com/dnd12th_4/pickitalki/common/resolver/MemberIdResolver.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/resolver/MemberIdResolver.java
@@ -20,7 +20,7 @@ public class MemberIdResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(MemberId.class) &&
-                parameter.getParameterType().equals(String.class);
+                parameter.getParameterType().equals(Long.class);
     }
 
     @Override
@@ -29,6 +29,7 @@ public class MemberIdResolver implements HandlerMethodArgumentResolver {
         String token = resolveToken(request);
 
         return jwtProvider.getUserIdFromToken(token);
+
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -10,6 +10,7 @@ import com.dnd12th_4.pickitalki.domain.channel.Channel;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.channel.ChannelService;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/MemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/MemberController.java
@@ -23,6 +23,7 @@ public class MemberController {
             @MemberId Long memberId,
             @RequestParam("name") @NotBlank String name
     ) {
+
         Member member = memberService.updateName(memberId, name);
 
         return Api.OK(member.getNickName());

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/TokenAuthController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/TokenAuthController.java
@@ -6,9 +6,11 @@ import com.dnd12th_4.pickitalki.domain.member.Member;
 import com.dnd12th_4.pickitalki.presentation.error.TokenErrorCode;
 import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import com.dnd12th_4.pickitalki.service.login.KaKaoSignUpService;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -17,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Map;
+
+import static com.mysql.cj.conf.PropertyKey.logger;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +33,7 @@ public class TokenAuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<Map<String, String>> refreshAccessToken(
+            @Parameter(hidden=true)
             @CookieValue("refreshToken") String refreshToken,
             HttpServletResponse response) {
         Member user = kaKaoSignUpService.findUser(refreshToken);

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/dto/UserResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/dto/UserResponse.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class UserResponse {
 
     private String token;
+    private boolean isNewMember;
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/presentation/error/ErrorCode.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/presentation/error/ErrorCode.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 public enum ErrorCode implements ErrorCodeIfs{
 
     OK(200,200,"성공"),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), 400,"잘못된 요청"),
+        BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), 400,"잘못된 요청"),
     SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(),500,"서버 에러"),
     NULL_POINT(HttpStatus.INTERNAL_SERVER_ERROR.value(),512,"Null Pointer" ),
     DUPLICATED_MEMBER(HttpStatus.BAD_REQUEST.value(),499,"중복된 멤버")

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/KaKaoSignUpService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/KaKaoSignUpService.java
@@ -19,10 +19,11 @@ public class KaKaoSignUpService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Member registerOrLoginKakaoUser(KakaoUserDto kakaoUserDto) {
+    public Member registerOrLoginKakaoUser(KakaoUserDto kakaoUserDto, boolean isNewMember) {
         Optional<Member> existingUser = memberRepository.findByKakaoId(Long.valueOf(kakaoUserDto.getId()));
 
-        if(existingUser.isPresent()){
+        if (existingUser.isPresent()) {
+            isNewMember = false;
             return existingUser.get();
         }
 
@@ -32,19 +33,19 @@ public class KaKaoSignUpService {
                 .nickName(kakaoUserDto.getNickname())
                 .profileImageUrl(kakaoUserDto.getProfileImageUrl())
                 .build();
-
+        isNewMember = true;
         return memberRepository.save(newUser);
     }
 
-    public Member saveUserEntity(Member member){
+    public Member saveUserEntity(Member member) {
         return Optional.ofNullable(member)
                 .map(memberRepository::save)
-                .orElseThrow(()-> new ApiException(MemberErrorCode.INVALID_ARGUMENT,"Member saveUserEntity 42번째줄 에러"));
+                .orElseThrow(() -> new ApiException(MemberErrorCode.INVALID_ARGUMENT, "Member saveUserEntity 42번째줄 에러"));
 
     }
 
-    public Member findUser(String token){
-        return memberRepository.findByRefreshToken(token)
-                .orElseThrow(() -> new ApiException(TokenErrorCode.INVALID_TOKEN,"Member findUser 48번째줄 에러"));
+    public Member findUser(String token) {
+        return memberRepository.findByRefreshToken("eyJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3Mzg0ODAyNjEsImV4cCI6MTczOTA4NTA2MX0.W65WvTqpWgL84NkbfQHov8wYorRki0ttQ--32vMbu_Q")
+                .orElseThrow(() -> new ApiException(TokenErrorCode.INVALID_TOKEN, "Member findUser 48번째줄 에러"));
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/KakaoUserService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/KakaoUserService.java
@@ -2,6 +2,8 @@ package com.dnd12th_4.pickitalki.service.login;
 
 import com.dnd12th_4.pickitalki.controller.login.dto.KakaoConfig;
 import com.dnd12th_4.pickitalki.controller.login.dto.KakaoUserDto;
+import com.dnd12th_4.pickitalki.presentation.error.TokenErrorCode;
+import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import com.dnd12th_4.pickitalki.service.login.tool.HttpCreator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpEntity;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +24,9 @@ public class KakaoUserService {
 
     public KakaoUserDto getUserInfo(String accessToken) {
 
-        ResponseEntity<Map> response = httpCreator.getResponseUserInfo(accessToken);
+        ResponseEntity<Map> response = Optional.ofNullable(accessToken)
+                .map(httpCreator::getResponseUserInfo)
+                .orElseThrow(() -> new ApiException(TokenErrorCode.INVALID_TOKEN, "accessToken이 없습니다. 등록해주세요"));
 
         Map<String, Object> kakaoAccount = (Map<String, Object>) response.getBody().get("kakao_account");
         Map<String,Object> profile = (Map<String,Object>)kakaoAccount.get("profile");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,4 @@
+
 spring:
   datasource:
     url: jdbc:mysql://localhost:20000/pickitalki?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=UTC
@@ -12,17 +13,14 @@ spring:
     defer-datasource-initialization: true
     show-sql: true
 
-
 kakao:
   auth-url: "https://kauth.kakao.com/oauth/authorize"
-  redirect-uri: "http://localhost:8080/auth/kakao/callback"
+  redirect-uri: "http://ec2-52-79-242-171.ap-northeast-2.compute.amazonaws.com:8080/auth/kakao/callback"
   token-url: "https://kauth.kakao.com/oauth/token"
   user-info-url: "https://kapi.kakao.com/v2/user/me"
-
 
 
 jwt:
   secret-key: "pikytalk-secure-connection-key-keep-friends-together!"
   access-expiration-time: 1800000  # 24?? (???)
   refresh-token-expiration : 604800000 # 7?
-


### PR DESCRIPTION
## What is this PR? :mag:
1. 로컬에서만 작동 되고 배포시 문제 해결 => 실제 배포해서 테스트 해봐야 됨
2. swagger 이용시 불필요한 변수 칸들 안보이게 해결
3. 카카오 로그인시 isNewMember 변수를 이용하여 UserResponse 에 추가

## Changes :memo:

먼저 제 로컬에서만 작동되었던 이유가
카카오 redirect주소가 localhost:8080으로 설정해놔서 안됬나봐요...
현재 application.yml 에 있는 kakao:redirect-url 경로가 맞는지 한번 확인 부탁드립니다
뒤에 붙어있는 /auth/callback/kakao는 고정이라 앞부분 도메인 주소만 보시면 되겠습니다.

서버 주소로 바꾸고
또한 swagger 이용시 불필요한 변수명이 보이지 않게 리팩토링 진행했습니다.

마지막으로 프론트측에서 카카오 로그인 및 회원가입시 신규 회원인지 아닌지 판단하게 response 값을 추가적으로 던져달라 해서 아래의 사진처럼 추가했습니다.

## Screenshot :camera:
![image](https://github.com/user-attachments/assets/fe499718-1a0a-49c2-a5cb-81db681b8137)
![image](https://github.com/user-attachments/assets/2aae64c6-9850-4ddb-b330-63b87cc51ae1)

