### PR TITLE
테이블 초기화 방식 수정 및 채널중복 입장 가능오류 해결

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -75,7 +75,9 @@ public class Channel extends BaseEntity implements Persistable<String> {
             throw new IllegalArgumentException("채널의 회원이 존재하지 않습니다.");
         }
 
-        if (channelMembers.contains(channelMember)) {
+        boolean isAlreadyExist = channelMembers.stream()
+                .anyMatch(ch -> ch.isSameMember(channelMember.getMember().getId()));
+        if (isAlreadyExist) {
             throw new IllegalArgumentException("이미 해당 채널에 존재하는 회원입니다.");
         }
     }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -42,10 +42,10 @@ public class ChannelMember extends BaseEntity {
     @JoinColumn(name = "member_id" ,nullable = false)
     private Member member;
 
-    @Column(nullable=true)
+    @Column(name = "member_code_name", nullable=true)
     private String memberCodeName;
 
-    @Column(columnDefinition = "varchar(50)", nullable = false)
+    @Column(columnDefinition = "varchar(10)", nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,9 +9,12 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     defer-datasource-initialization: true
     show-sql: true
+  sql:
+    init:
+      mode: always
 
 kakao:
   auth-url: "https://kauth.kakao.com/oauth/authorize"

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -6,8 +6,8 @@ create TABLE if not exists `pickitalki`.members (
     nick_name VARCHAR(50) NOT NULL,
     profile_image_url TEXT NULL,
     refresh_token TEXT NULL,
-    created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1) NOT NULL DEFAULT 0
 );
 
@@ -15,13 +15,17 @@ create TABLE if not exists `pickitalki`.channels (
     uuid BINARY(16) PRIMARY KEY,
     name VARCHAR(30) NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1) NOT NULL DEFAULT 0
 );
 create TABLE if not exists `pickitalki`.channel_members (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     channel_uuid BINARY(16) NOT NULL,
-    member_id VARCHAR(30) NOT NULL,
+    member_id BIGINT NOT NULL,
+    member_code_name VARCHAR(20),
+    role VARCHAR(10) NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1) NOT NULL DEFAULT 0,
     FOREIGN KEY (channel_uuid) REFERENCES channels(uuid),
     FOREIGN KEY (member_id) REFERENCES members(id)
@@ -30,15 +34,15 @@ create TABLE if not exists `pickitalki`.channel_members (
 create TABLE if not exists `pickitalki`.questions (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
     channel_uuid BINARY(16) NOT NULL,
-    channel_member_id BIGINT NOT NULL,
+    author_id BIGINT NOT NULL,
     content VARCHAR(255) NOT NULL,
-    question_number BIGINT NOT NULL,
     is_anonymous BOOLEAN NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(30),
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1) NOT NULL DEFAULT 0,
     FOREIGN KEY (channel_uuid) REFERENCES channels(uuid),
-    FOREIGN KEY (channel_member_id) REFERENCES channel_members(id)
+    FOREIGN KEY (author_id) REFERENCES members(id)
 );
 
 create TABLE if not exists `pickitalki`.answers (
@@ -49,6 +53,7 @@ create TABLE if not exists `pickitalki`.answers (
     is_anonymous BOOLEAN NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(10),
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1) NOT NULL DEFAULT 0,
     FOREIGN KEY (question_id) REFERENCES questions(id),
     FOREIGN KEY (member_id) REFERENCES members(id)


### PR DESCRIPTION
## What is this PR? :mag:
schema.sql로 테이블을 초기화하도록 application.yml의 설정을 변경했습니다. 이제 도메인의 속성을 수정한다면, schema.sql의 DDL문에까지 반영해야합니다.

채널의 주인이 초대코드로 또 채널에 입장 가능했던 오류가 있었습니다. Channel의 validateChannelMember()를 잘못구현했었습니다. 이를 수정했습니다.

## Changes :memo:
<img width="812" alt="image" src="https://github.com/user-attachments/assets/44b027e7-ab90-4b77-943f-72919a97e058" />

## Screenshot :camera:
