### PR TITLE
[feat] : tutorial api 기능 구현

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/MemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/MemberController.java
@@ -1,15 +1,16 @@
 package com.dnd12th_4.pickitalki.controller.login;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.controller.login.dto.response.TutorialResponse;
 import com.dnd12th_4.pickitalki.domain.member.Member;
+import com.dnd12th_4.pickitalki.domain.member.Tutorial;
+import com.dnd12th_4.pickitalki.domain.member.TutorialStatus;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.login.MemberService;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,4 +30,25 @@ public class MemberController {
         return Api.OK(member.getNickName());
     }
 
+    @GetMapping("/tutorial")
+    public ResponseEntity<TutorialResponse> doTutorial(
+            @MemberId Long memberId
+    ){
+
+       TutorialStatus tutorialStatus = memberService.hasCompletedTutorial(memberId);
+        TutorialResponse tutorialResponse = new TutorialResponse(tutorialStatus);
+
+        return ResponseEntity.ok(tutorialResponse);
+    }
+
+    @PatchMapping("/tutorial/update")
+    public ResponseEntity<TutorialResponse> updateTutorial(
+            @MemberId Long memberId
+    ){
+
+        TutorialStatus tutorialStatus = memberService.update(memberId);
+        TutorialResponse tutorialResponse = new TutorialResponse(tutorialStatus);
+
+        return ResponseEntity.ok(tutorialResponse);
+    }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/dto/response/TutorialResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/dto/response/TutorialResponse.java
@@ -1,0 +1,6 @@
+package com.dnd12th_4.pickitalki.controller.login.dto.response;
+
+import com.dnd12th_4.pickitalki.domain.member.TutorialStatus;
+
+public record TutorialResponse(TutorialStatus tutorialStatus) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/member/Tutorial.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/member/Tutorial.java
@@ -1,0 +1,35 @@
+package com.dnd12th_4.pickitalki.domain.member;
+
+
+
+import com.dnd12th_4.pickitalki.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "tutorial")
+public class Tutorial extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(columnDefinition = "varchar(10)",nullable = false)
+    @Enumerated(EnumType.STRING)
+    private TutorialStatus status;
+
+    public void setStatus(TutorialStatus status) {
+        this.status = status;
+    }
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/member/TutorialRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/member/TutorialRepository.java
@@ -1,0 +1,16 @@
+package com.dnd12th_4.pickitalki.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface TutorialRepository extends JpaRepository<Tutorial,Long> {
+
+    @Query("SELECT t.status from Tutorial t where t.memberId =:memberId")
+    Optional<TutorialStatus> findStatusByMemberId(@Param("memberId")Long memberId);
+
+    Optional<Tutorial> findByMemberId(Long memberId);
+
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/member/TutorialStatus.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/member/TutorialStatus.java
@@ -1,0 +1,7 @@
+package com.dnd12th_4.pickitalki.domain.member;
+
+public enum TutorialStatus {
+    PASS,
+    NON_PASS
+    ;
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
@@ -1,9 +1,9 @@
 package com.dnd12th_4.pickitalki.service.login;
 
 
-import com.dnd12th_4.pickitalki.domain.member.Member;
-import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
+import com.dnd12th_4.pickitalki.domain.member.*;
 import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
+import com.dnd12th_4.pickitalki.presentation.error.MemberErrorCode;
 import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,14 +14,41 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final TutorialRepository tutorialRepository;
 
     @Transactional
-    public Member updateName(Long memberId, String name){
+    public Member updateName(Long memberId, String name) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "해당 member가 DB에 없습니다."));
 
         member.setNickName(name);
+
+        Tutorial tutorial = buildTutorial(member);
+        tutorialRepository.save(tutorial);
+
         return member;
     }
 
+    private Tutorial buildTutorial(Member member) {
+        return Tutorial.builder()
+                .memberId(member.getId())
+                .status(TutorialStatus.NON_PASS)
+                .build();
+    }
+
+    public TutorialStatus hasCompletedTutorial(Long memberId) {
+
+        return tutorialRepository.findStatusByMemberId(memberId)
+                .orElseThrow(() -> new ApiException(MemberErrorCode.INVALID_ARGUMENT, "Toturial에 찾고자 하는 데이터 없음"));
+    }
+
+    @Transactional
+    public TutorialStatus update(Long memberId) {
+        Tutorial tutorial = tutorialRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new ApiException(MemberErrorCode.INVALID_ARGUMENT, "Toturial에 찾고자 하는 데이터 없음"));
+
+        tutorial.setStatus(TutorialStatus.PASS);
+
+        return tutorial.getStatus();
+    }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,60 +1,74 @@
-
-create TABLE if not exists `pickitalki`.members (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    kakao_id BIGINT UNIQUE NOT NULL,
-    email VARCHAR(100) UNIQUE,
-    nick_name VARCHAR(50) NOT NULL,
-    profile_image_url TEXT NULL,
-    refresh_token TEXT NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-    is_deleted TINYINT(1) NOT NULL DEFAULT 0
+create TABLE if not exists `pickitalki`.members
+(
+    id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+    kakao_id          BIGINT UNIQUE NOT NULL,
+    email             VARCHAR(100) UNIQUE,
+    nick_name         VARCHAR(50)   NOT NULL,
+    profile_image_url TEXT          NULL,
+    refresh_token     TEXT          NULL,
+    created_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        DATETIME               DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    is_deleted        TINYINT(1)    NOT NULL DEFAULT 0
 );
 
-create TABLE if not exists `pickitalki`.channels (
-    uuid BINARY(16) PRIMARY KEY,
-    name VARCHAR(30) NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-    is_deleted TINYINT(1) NOT NULL DEFAULT 0
+create TABLE if not exists `pickitalki`.channels
+(
+    uuid       BINARY(16) PRIMARY KEY,
+    name       VARCHAR(30) NOT NULL,
+    created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME             DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    is_deleted TINYINT(1)  NOT NULL DEFAULT 0
 );
-create TABLE if not exists `pickitalki`.channel_members (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    channel_uuid BINARY(16) NOT NULL,
-    member_id BIGINT NOT NULL,
+create TABLE if not exists `pickitalki`.channel_members
+(
+    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
+    channel_uuid     BINARY(16)  NOT NULL,
+    member_id        BIGINT      NOT NULL,
     member_code_name VARCHAR(20),
-    role VARCHAR(10) NOT NULL,
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-    is_deleted TINYINT(1) NOT NULL DEFAULT 0,
-    FOREIGN KEY (channel_uuid) REFERENCES channels(uuid),
-    FOREIGN KEY (member_id) REFERENCES members(id)
+    role             VARCHAR(10) NOT NULL,
+    created_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       DATETIME             DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    is_deleted       TINYINT(1)  NOT NULL DEFAULT 0,
+    FOREIGN KEY (channel_uuid) REFERENCES channels (uuid),
+    FOREIGN KEY (member_id) REFERENCES members (id)
 );
 
-create TABLE if not exists `pickitalki`.questions (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    channel_uuid BINARY(16) NOT NULL,
-    author_id BIGINT NOT NULL,
-    content VARCHAR(255) NOT NULL,
-    is_anonymous BOOLEAN NOT NULL DEFAULT FALSE,
+create TABLE if not exists `pickitalki`.questions
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    channel_uuid   BINARY(16)   NOT NULL,
+    author_id      BIGINT       NOT NULL,
+    content        VARCHAR(255) NOT NULL,
+    is_anonymous   BOOLEAN      NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(30),
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-    is_deleted TINYINT(1) NOT NULL DEFAULT 0,
-    FOREIGN KEY (channel_uuid) REFERENCES channels(uuid),
-    FOREIGN KEY (author_id) REFERENCES members(id)
+    created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     DATETIME              DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    is_deleted     TINYINT(1)   NOT NULL DEFAULT 0,
+    FOREIGN KEY (channel_uuid) REFERENCES channels (uuid),
+    FOREIGN KEY (author_id) REFERENCES members (id)
 );
 
-create TABLE if not exists `pickitalki`.answers (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    question_id BIGINT NOT NULL,
-    member_id BIGINT NOT NULL,
-    content VARCHAR(500) NOT NULL,
-    is_anonymous BOOLEAN NOT NULL DEFAULT FALSE,
+create TABLE if not exists `pickitalki`.answers
+(
+    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
+    question_id    BIGINT       NOT NULL,
+    member_id      BIGINT       NOT NULL,
+    content        VARCHAR(500) NOT NULL,
+    is_anonymous   BOOLEAN      NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(10),
-    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-    is_deleted TINYINT(1) NOT NULL DEFAULT 0,
-    FOREIGN KEY (question_id) REFERENCES questions(id),
-    FOREIGN KEY (member_id) REFERENCES members(id)
+    created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     DATETIME              DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    is_deleted     TINYINT(1)   NOT NULL DEFAULT 0,
+    FOREIGN KEY (question_id) REFERENCES questions (id),
+    FOREIGN KEY (member_id) REFERENCES members (id)
+);
+
+CREATE TABLE IF NOT EXISTS tutorial
+(
+    id         BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_id  BIGINT      NOT NULL,
+    status     VARCHAR(10) NOT NULL,
+    created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME             DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    is_deleted TINYINT(1)  NOT NULL DEFAULT 0
 );


### PR DESCRIPTION
## What is this PR? :mag:
Tutorial api 기능을 추가했습니다.

## Changes :memo:
프론트 측에서 카카오 로그인or 회원가입을 하면 이 회원이 로그인한 사용자인지 회원가입한 사용자인지 구별을 못했다고 합니다.
저희는 현재 카카오 시작하기 버튼만있기 때문에

그래서 tutorial기능을 추가하여 channel 생성 or 가입 의 튜토리얼을 끝낼경우 tutorial의 상태를 PASS로 변경해주는 로직을 개발했습니다.

### [api 요청과정]
로그인 or 회원가입 후 프론트측에서 tutorial api 송신 => 해당 유저 NON_PASS 일경우 튜토리얼 진행 
PASS일 경우 튜토리얼 진행하지 않고 바로 메인 홈 화면
튜토리얼 다 진행한 회원은 tutorial api 송신을 하여 기존 NON_PASS 를 PASS로 update

추가적으로 tutorial 테이블을 만들었습니다.

schema.sql 파일에도 tutorial 테이블 추가했습니다.


## Screenshot :camera:
![image](https://github.com/user-attachments/assets/e1d30f3b-63bc-4fca-899a-a216c11cfe6a)

![image](https://github.com/user-attachments/assets/8dace0e9-390e-4c59-8a8a-c8ca2f0536ac)

