### PR TITLE
[feat] 채널에 속한 회원정보 조회기능

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -3,6 +3,7 @@ package com.dnd12th_4.pickitalki.controller.channel;
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelJoinResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelSpecificResponse;
@@ -10,7 +11,6 @@ import com.dnd12th_4.pickitalki.controller.channel.dto.InviteCodeDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.MemberCodeNameResponse;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.channel.ChannelService;
-import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -55,6 +55,16 @@ public class ChannelController {
         MemberCodeNameResponse memberCodeNameResponse = channelService.updateCodeName(memberId, channelId, codeName);
 
         return Api.OK(memberCodeNameResponse);
+    }
+
+    @GetMapping("/{channelId}/members")
+    public Api<List<ChannelMemberResponse>> findChannelMembers(
+            @MemberId Long memberId,
+            @PathVariable("channelId") String channelId
+    ) {
+        List<ChannelMemberResponse> channelMembers = channelService.findChannelMembers(memberId, channelId);
+
+        return Api.OK(channelMembers);
     }
 
     @GetMapping("/inviteCode")

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -3,6 +3,7 @@ package com.dnd12th_4.pickitalki.controller.channel;
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelJoinResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
@@ -58,13 +59,17 @@ public class ChannelController {
     }
 
     @GetMapping("/{channelId}/members")
-    public Api<List<ChannelMemberResponse>> findChannelMembers(
+    public Api<ChannelMemberResponse> findChannelMembers(
             @MemberId Long memberId,
             @PathVariable("channelId") String channelId
     ) {
-        List<ChannelMemberResponse> channelMembers = channelService.findChannelMembers(memberId, channelId);
+        List<ChannelMemberDto> channelMembers = channelService.findChannelMembers(memberId, channelId);
 
-        return Api.OK(channelMembers);
+        return Api.OK(ChannelMemberResponse.builder()
+                .memberCount(channelMembers.size())
+                .channelMembers(channelMembers)
+                .build()
+        );
     }
 
     @GetMapping("/inviteCode")

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberDto.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberDto.java
@@ -1,0 +1,7 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ChannelMemberDto(long channelMemberId, String nickName, String profileImageUrl) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberResponse.java
@@ -1,13 +1,7 @@
 package com.dnd12th_4.pickitalki.controller.channel.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.Builder;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class ChannelMemberResponse {
-
-    private Long channelMemberId;
+@Builder
+public record ChannelMemberResponse(long channelMemberId, String nickName, String profileImageUrl) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberResponse.java
@@ -2,6 +2,8 @@ package com.dnd12th_4.pickitalki.controller.channel.dto;
 
 import lombok.Builder;
 
+import java.util.List;
+
 @Builder
-public record ChannelMemberResponse(long channelMemberId, String nickName, String profileImageUrl) {
+public record ChannelMemberResponse(long memberCount, List<ChannelMemberDto> channelMembers) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelShowAllResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelShowAllResponse.java
@@ -14,6 +14,6 @@ public class ChannelShowAllResponse {
     private String channelRoomName;
     private String channelOwnerName;
     private Long countPerson;
-    private Long singalCount;
+    private Long signalCount;
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelSpecificResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelSpecificResponse.java
@@ -4,6 +4,6 @@ import lombok.Builder;
 
 @Builder
 public record ChannelSpecificResponse(String channelRoomName, String channelOwnerName,
-                                      Long countPerson, Long singalCount) {
+                                      Long countPerson, Long signalCount) {
     //응답 1개에 대한 섬네일 정보- 응답자코드네임, 응답내용, created_at 필요
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/QuestionController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/QuestionController.java
@@ -1,6 +1,10 @@
 package com.dnd12th_4.pickitalki.controller.question;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.controller.question.dto.QuestionCreateRequest;
+import com.dnd12th_4.pickitalki.controller.question.dto.QuestionCreateResponse;
+import com.dnd12th_4.pickitalki.controller.question.dto.QuestionResponse;
+import com.dnd12th_4.pickitalki.controller.question.dto.TodayQuestionResponse;
 import com.dnd12th_4.pickitalki.service.question.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/QuestionResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/QuestionResponse.java
@@ -1,4 +1,0 @@
-package com.dnd12th_4.pickitalki.controller.question;
-
-public record QuestionResponse(String authorName, long signalNumber, String content, String createdAt) {
-}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/TodayQuestionResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/TodayQuestionResponse.java
@@ -1,7 +1,0 @@
-package com.dnd12th_4.pickitalki.controller.question;
-
-import lombok.Builder;
-
-@Builder
-public record TodayQuestionResponse(long signalCount, String content, boolean isExist, String time) {
-}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionCreateRequest.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionCreateRequest.java
@@ -1,4 +1,4 @@
-package com.dnd12th_4.pickitalki.controller.question;
+package com.dnd12th_4.pickitalki.controller.question.dto;
 
 public record QuestionCreateRequest(String content, boolean isAnonymous, String anonymousName) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionCreateResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionCreateResponse.java
@@ -1,4 +1,4 @@
-package com.dnd12th_4.pickitalki.controller.question;
+package com.dnd12th_4.pickitalki.controller.question.dto;
 
 import lombok.Builder;
 

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionResponse.java
@@ -1,0 +1,4 @@
+package com.dnd12th_4.pickitalki.controller.question.dto;
+
+public record QuestionResponse(String writerName, long signalNumber, String content, String createdAt) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/TodayQuestionResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/TodayQuestionResponse.java
@@ -1,0 +1,7 @@
+package com.dnd12th_4.pickitalki.controller.question.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TodayQuestionResponse(long signalCount, boolean isExist, String content, String writer, String time) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Persistable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 import static jakarta.persistence.CascadeType.MERGE;
@@ -82,10 +83,10 @@ public class Channel extends BaseEntity implements Persistable<String> {
         }
     }
 
-    public ChannelMember findChannelMemberById(Long memberId) {
-        return channelMembers.stream().filter(channelMember -> channelMember.isSameMember(memberId))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 채널에 존재하지 않습니다."));
+    public Optional<ChannelMember> findChannelMemberById(Long memberId) {
+        return channelMembers.stream()
+                .filter(channelMember -> channelMember.isSameMember(memberId))
+                .findFirst();
     }
 
     @Override

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -131,7 +131,7 @@ public class ChannelService {
                 .channelOwnerName(ownerName)
                 .channelRoomName(channel.getName())
                 .countPerson((long) channel.getChannelMembers().size())
-                .singalCount(signalCount)
+                .signalCount(signalCount)
                 .build();
     }
 
@@ -161,7 +161,7 @@ public class ChannelService {
                 .channelOwnerName(ownerName)
                 .channelRoomName(channel.getName())
                 .countPerson((long) channel.getChannelMembers().size())
-                .singalCount(signalCount)
+                .signalCount(signalCount)
                 .build();
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -2,7 +2,7 @@ package com.dnd12th_4.pickitalki.service.channel;
 
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelJoinResponse;
-import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelSpecificResponse;
@@ -17,9 +17,9 @@ import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
 import com.dnd12th_4.pickitalki.domain.question.QuestionRepository;
 import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
 import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -137,7 +137,7 @@ public class ChannelService {
                 .build();
     }
 
-
+    @Transactional(readOnly= true)
     public String findInviteCode(Long memberId, String channelName) {
         Channel channel = channelRepository.findByName(channelName)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이름의 채널을 찾을 수 없습니다. 초대코드를 응답할 수 없습니다."));
@@ -147,6 +147,7 @@ public class ChannelService {
         return channelMember.getInviteCode();
     }
 
+    @Transactional(readOnly= true)
     public ChannelSpecificResponse findChannelByChannelName(Long memberId, String channelName) {
         Channel channel = channelRepository.findByName(channelName)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이름의 채널을 찾을 수 없습니다. 채널정보를 응답할 수 없습니다."));
@@ -168,7 +169,8 @@ public class ChannelService {
                 .build();
     }
 
-    public List<ChannelMemberResponse> findChannelMembers(Long memberId, String channelId) {
+    @Transactional(readOnly= true)
+    public List<ChannelMemberDto> findChannelMembers(Long memberId, String channelId) {
         UUID channelUuid = UUID.fromString(channelId);
         Channel channel = channelRepository.findByUuid(channelUuid)
                 .orElseThrow(() -> new IllegalArgumentException("해당 채널을 찾을 수 없습니다. 채널의 회원정보를 응답할 수 없습니다."));
@@ -176,7 +178,7 @@ public class ChannelService {
                 .orElseThrow(() -> new IllegalArgumentException("채널에 해당 회원이 존재하지 않습니다. 채널의 회원정보들을 조회할 권한이 없습니다."));
 
         return channel.getChannelMembers()
-                .stream().map(cm -> ChannelMemberResponse.builder()
+                .stream().map(cm -> ChannelMemberDto.builder()
                         .nickName(cm.getMemberCodeName())
                         .profileImageUrl(cm.getMember().getProfileImageUrl())
                         .channelMemberId(cm.getId())

--- a/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
@@ -35,7 +35,8 @@ public class QuestionService {
         Channel channel = channelRepository.findByUuid(channelUuid)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 채널을 찾을 수 없습니다. 새 시그널을 생성할 수 없습니다."));
 
-        ChannelMember channelMember = channel.findChannelMemberById(memberId);
+        ChannelMember channelMember = channel.findChannelMemberById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("채널에 해당 회원이 존재하지 않습니다. 질문을 생성할 권한이 없습니다."));
         long questionCount = questionRepository.countByChannelUuid(channelUuid);
 
         Question question = questionRepository.save(

--- a/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
@@ -1,7 +1,7 @@
 package com.dnd12th_4.pickitalki.service.question;
 
-import com.dnd12th_4.pickitalki.controller.question.QuestionResponse;
-import com.dnd12th_4.pickitalki.controller.question.TodayQuestionResponse;
+import com.dnd12th_4.pickitalki.controller.question.dto.QuestionResponse;
+import com.dnd12th_4.pickitalki.controller.question.dto.TodayQuestionResponse;
 import com.dnd12th_4.pickitalki.domain.channel.Channel;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelRepository;
@@ -55,12 +55,14 @@ public class QuestionService {
         return questionRepository.findTodayQuestion(channelUuid)
                 .map(question -> TodayQuestionResponse.builder()
                         .isExist(true)
+                        .writer(question.getAuthorName())
                         .signalCount(question.getQuestionNumber())
                         .time(formatToKoreanTime(question.getCreatedAt()))
                         .content(question.getContent())
                         .build())
                 .orElseGet(() -> TodayQuestionResponse.builder()
                         .isExist(false)
+                        .writer(null)
                         .signalCount(questionRepository.findMaxQuestionNumber(channelUuid) + 1)
                         .time(formatToKoreanTime(LocalDateTime.now()))
                         .content(null)


### PR DESCRIPTION
## What is this PR? :mag:
"api/channels/{channelId}/members" API로 채널에 속한 회원정보들 조회하는 기능. 
아래의 화면에서 필요할 거라 예상
<img width="169" alt="image" src="https://github.com/user-attachments/assets/108be2ce-8dbe-44f9-aa2b-da778d9c8a62" />

## Changes :memo:
그 외에
singal이라는 오타 수정 
답변dto에서 작성자이름이 빠져있던 것 수정 
## Screenshot :camera:
