### PR TITLE
[Feat] 마이페이지 조회 기능

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/ChannelFriendResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/ChannelFriendResponse.java
@@ -1,0 +1,7 @@
+package com.dnd12th_4.pickitalki.controller.member;
+
+import lombok.Builder;
+
+@Builder
+public record ChannelFriendResponse(Long channelMemberId, String channelName, String codeName, String profileImage) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
@@ -53,6 +53,14 @@ public class MemberController {
         return Api.OK(allParticipateMyInfo);
     }
 
+    @GetMapping("/friends")
+    public Api<List<ChannelFriendResponse>> findMyFriends(
+            @MemberId Long memberId
+    ) {
+        List<ChannelFriendResponse> channelFriends = memberService.findChannelFriends(memberId);
+
+        return Api.OK(channelFriends);
+    }
 
     @GetMapping("/tutorial")
     public ResponseEntity<TutorialResponse> doTutorial(

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
@@ -1,6 +1,7 @@
 package com.dnd12th_4.pickitalki.controller.member;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.login.dto.response.TutorialResponse;
 import com.dnd12th_4.pickitalki.domain.member.Member;
 import com.dnd12th_4.pickitalki.domain.member.TutorialStatus;
@@ -44,11 +45,29 @@ public class MemberController {
         return Api.OK(memberResponse);
     }
 
-    @GetMapping("/channelMembers")
-    public Api<List<MyChannelMemberResponse>> findMyChannelMemberInfo(
+    @GetMapping("/channelMembers/all")
+    public Api<List<MyChannelMemberResponse>> findAllMyChannelMemberInfo(
             @MemberId Long memberId
     ) {
-        List<MyChannelMemberResponse> allParticipateMyInfo = memberService.findAllParticipateMyInfo(memberId);
+        List<MyChannelMemberResponse> allParticipateMyInfo = memberService.findAllChannelMyInfo(memberId, ChannelControllerEnums.SHOWALL);
+
+        return Api.OK(allParticipateMyInfo);
+    }
+
+    @GetMapping("/channelMembers/own")
+    public Api<List<MyChannelMemberResponse>> findMyOwnChannelMemberInfo(
+            @MemberId Long memberId
+    ) {
+        List<MyChannelMemberResponse> allParticipateMyInfo = memberService.findAllChannelMyInfo(memberId, ChannelControllerEnums.MADEALL);
+
+        return Api.OK(allParticipateMyInfo);
+    }
+
+    @GetMapping("/channelMembers/invited")
+    public Api<List<MyChannelMemberResponse>> findMyInvitedChannelMemberInfo(
+            @MemberId Long memberId
+    ) {
+        List<MyChannelMemberResponse> allParticipateMyInfo = memberService.findAllChannelMyInfo(memberId, ChannelControllerEnums.INVITEDALL);
 
         return Api.OK(allParticipateMyInfo);
     }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
@@ -41,6 +43,16 @@ public class MemberController {
 
         return Api.OK(memberResponse);
     }
+
+    @GetMapping("/channelMembers")
+    public Api<List<MyChannelMemberResponse>> findMyChannelMemberInfo(
+            @MemberId Long memberId
+    ) {
+        List<MyChannelMemberResponse> allParticipateMyInfo = memberService.findAllParticipateMyInfo(memberId);
+
+        return Api.OK(allParticipateMyInfo);
+    }
+
 
     @GetMapping("/tutorial")
     public ResponseEntity<TutorialResponse> doTutorial(

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
@@ -1,16 +1,20 @@
-package com.dnd12th_4.pickitalki.controller.login;
+package com.dnd12th_4.pickitalki.controller.member;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
 import com.dnd12th_4.pickitalki.controller.login.dto.response.TutorialResponse;
 import com.dnd12th_4.pickitalki.domain.member.Member;
-import com.dnd12th_4.pickitalki.domain.member.Tutorial;
 import com.dnd12th_4.pickitalki.domain.member.TutorialStatus;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.login.MemberService;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,10 +28,18 @@ public class MemberController {
             @MemberId Long memberId,
             @RequestParam("name") @NotBlank String name
     ) {
-
         Member member = memberService.updateName(memberId, name);
 
         return Api.OK(member.getNickName());
+    }
+
+    @GetMapping
+    public Api<MemberResponse> findMemberInfo(
+            @MemberId Long memberId
+    ) {
+        MemberResponse memberResponse = memberService.findMemberById(memberId);
+
+        return Api.OK(memberResponse);
     }
 
     @GetMapping("/tutorial")

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberResponse.java
@@ -1,0 +1,7 @@
+package com.dnd12th_4.pickitalki.controller.member;
+
+import lombok.Builder;
+
+@Builder
+public record MemberResponse(String name, String email, String profileImage) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/MyChannelMemberResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/MyChannelMemberResponse.java
@@ -1,0 +1,8 @@
+package com.dnd12th_4.pickitalki.controller.member;
+
+import lombok.Builder;
+
+@Builder
+public record MyChannelMemberResponse(Long channelMemberId, String channelId, String codeName, String channelName,
+                                      String profileImage) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -15,6 +15,7 @@ import org.hibernate.type.SqlTypes;
 import org.springframework.data.domain.Persistable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -56,16 +57,6 @@ public class Channel extends BaseEntity implements Persistable<String> {
         this(UUID.randomUUID(), name);
     }
 
-    @Override
-    public boolean isNew() {
-        return isNull(createdAt);
-    }
-
-    @Override
-    public String getId() {
-        return uuid.toString();
-    }
-
     public void joinChannelMember(ChannelMember channelMember){
         validateChannelMember(channelMember);
         channelMembers.add(channelMember);
@@ -87,6 +78,20 @@ public class Channel extends BaseEntity implements Persistable<String> {
         return channelMembers.stream()
                 .filter(channelMember -> channelMember.isSameMember(memberId))
                 .findFirst();
+    }
+
+    public List<ChannelMember> getChannelMembers() {
+        return Collections.unmodifiableList(channelMembers);
+    }
+
+    @Override
+    public boolean isNew() {
+        return isNull(createdAt);
+    }
+
+    @Override
+    public String getId() {
+        return uuid.toString();
     }
 
     @Override

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -45,6 +45,12 @@ public class ChannelMember extends BaseEntity {
     @Column(name = "member_code_name", nullable=true)
     private String memberCodeName;
 
+    @Column(name = "profile_image", nullable=true)
+    private String profileImage;
+
+    @Column(name = "is_using_default_profile", nullable = false)
+    private boolean isUsingDefaultProfile = true;
+
     @Column(columnDefinition = "varchar(10)", nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -57,6 +63,8 @@ public class ChannelMember extends BaseEntity {
         this.channel = channel;
         this.member = member;
         this.memberCodeName = memberCodeName;
+        this.isUsingDefaultProfile = true;
+        this.profileImage = null;
         this.role = role;
     }
 
@@ -86,6 +94,11 @@ public class ChannelMember extends BaseEntity {
         return Base64.getUrlEncoder()
                 .withoutPadding()
                 .encodeToString(this.channel.getUuid().toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    public void setCustomProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+        this.isUsingDefaultProfile = false;
     }
 
     @Override

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -96,6 +96,13 @@ public class ChannelMember extends BaseEntity {
                 .encodeToString(this.channel.getUuid().toString().getBytes(StandardCharsets.UTF_8));
     }
 
+    public String getProfileImage() {
+        if (isUsingDefaultProfile) {
+            return member.getProfileImageUrl();
+        }
+        return profileImage;
+    }
+
     public void setCustomProfileImage(String profileImage) {
         this.profileImage = profileImage;
         this.isUsingDefaultProfile = false;

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
@@ -1,6 +1,8 @@
 package com.dnd12th_4.pickitalki.domain.channel;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -8,4 +10,12 @@ import java.util.List;
 @Repository
 public interface ChannelMemberRepository  extends JpaRepository<ChannelMember,Long> {
     List<ChannelMember> findByMemberId(Long memberId);
+
+    @Query("""
+    SELECT cm FROM ChannelMember cm
+    JOIN FETCH cm.channel c
+    JOIN FETCH c.channelMembers friends
+    WHERE cm.member.id = :memberId
+""")
+    List<ChannelMember> findMeOnChannel(@Param("memberId") Long memberId);
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberRepository.java
@@ -3,8 +3,9 @@ package com.dnd12th_4.pickitalki.domain.channel;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ChannelMemberRepository  extends JpaRepository<ChannelMember,Long> {
-
-
+    List<ChannelMember> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
@@ -1,6 +1,7 @@
 package com.dnd12th_4.pickitalki.service.login;
 
 
+import com.dnd12th_4.pickitalki.controller.member.ChannelFriendResponse;
 import com.dnd12th_4.pickitalki.controller.member.MemberResponse;
 import com.dnd12th_4.pickitalki.controller.member.MyChannelMemberResponse;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
@@ -53,8 +54,7 @@ public class MemberService {
                 .channelMemberId(channelMember.getId())
                 .channelName(channelMember.getChannel().getName())
                 .codeName(channelMember.getMemberCodeName())
-                .profileImage(channelMember.isUsingDefaultProfile()?
-                        channelMember.getMember().getProfileImageUrl(): channelMember.getProfileImage())
+                .profileImage(channelMember.getProfileImage())
                 .channelId(channelMember.getChannel().getId())
                 .build();
     }
@@ -93,5 +93,22 @@ public class MemberService {
         tutorial.setStatus(TutorialStatus.PASS);
 
         return tutorial.getStatus();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChannelFriendResponse> findChannelFriends(Long memberId) {
+        List<ChannelMember> meOnChannel = channelMemberRepository.findMeOnChannel(memberId);
+
+        return meOnChannel.stream()
+                .flatMap(me -> me.getChannel().getChannelMembers().stream()
+                        .filter(friend -> !friend.equals(me))
+                        .map(friend -> ChannelFriendResponse.builder()
+                                .channelMemberId(friend.getId())
+                                .channelName(friend.getChannel().getName())
+                                .codeName(friend.getMemberCodeName())
+                                .profileImage(friend.getProfileImage())
+                                .build())
+                )
+                .toList();
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
@@ -1,7 +1,12 @@
 package com.dnd12th_4.pickitalki.service.login;
 
 
-import com.dnd12th_4.pickitalki.domain.member.*;
+import com.dnd12th_4.pickitalki.controller.member.MemberResponse;
+import com.dnd12th_4.pickitalki.domain.member.Member;
+import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
+import com.dnd12th_4.pickitalki.domain.member.Tutorial;
+import com.dnd12th_4.pickitalki.domain.member.TutorialRepository;
+import com.dnd12th_4.pickitalki.domain.member.TutorialStatus;
 import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
 import com.dnd12th_4.pickitalki.presentation.error.MemberErrorCode;
 import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
@@ -15,6 +20,17 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final TutorialRepository tutorialRepository;
+
+    public MemberResponse findMemberById(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. 회원정보를 조회할 수 없습니다."));
+
+        return MemberResponse.builder()
+                .name(member.getNickName())
+                .email(member.getEmail())
+                .profileImage(member.getProfileImageUrl())
+                .build();
+    }
 
     @Transactional
     public Member updateName(Long memberId, String name) {

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
@@ -1,11 +1,13 @@
 package com.dnd12th_4.pickitalki.service.login;
 
 
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.member.ChannelFriendResponse;
 import com.dnd12th_4.pickitalki.controller.member.MemberResponse;
 import com.dnd12th_4.pickitalki.controller.member.MyChannelMemberResponse;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMemberRepository;
+import com.dnd12th_4.pickitalki.domain.channel.Role;
 import com.dnd12th_4.pickitalki.domain.member.Member;
 import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
 import com.dnd12th_4.pickitalki.domain.member.Tutorial;
@@ -41,10 +43,15 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public List<MyChannelMemberResponse> findAllParticipateMyInfo(Long memberId) {
+    public List<MyChannelMemberResponse> findAllChannelMyInfo(Long memberId, ChannelControllerEnums status) {
         List<ChannelMember> myChannelMembers = channelMemberRepository.findByMemberId(memberId);
 
         return myChannelMembers.stream()
+                .filter(channelMember ->
+                        status == ChannelControllerEnums.SHOWALL ||
+                                (status == ChannelControllerEnums.MADEALL && channelMember.getRole() == Role.OWNER) ||
+                                (status == ChannelControllerEnums.MADEALL && channelMember.getRole() == Role.MEMBER)
+                )
                 .map(MemberService::buildChannelMemberResponse)
                 .toList();
     }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
@@ -2,6 +2,9 @@ package com.dnd12th_4.pickitalki.service.login;
 
 
 import com.dnd12th_4.pickitalki.controller.member.MemberResponse;
+import com.dnd12th_4.pickitalki.controller.member.MyChannelMemberResponse;
+import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
+import com.dnd12th_4.pickitalki.domain.channel.ChannelMemberRepository;
 import com.dnd12th_4.pickitalki.domain.member.Member;
 import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
 import com.dnd12th_4.pickitalki.domain.member.Tutorial;
@@ -14,13 +17,17 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
     private final MemberRepository memberRepository;
     private final TutorialRepository tutorialRepository;
+    private final ChannelMemberRepository channelMemberRepository;
 
+    @Transactional(readOnly = true)
     public MemberResponse findMemberById(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. 회원정보를 조회할 수 없습니다."));
@@ -29,6 +36,26 @@ public class MemberService {
                 .name(member.getNickName())
                 .email(member.getEmail())
                 .profileImage(member.getProfileImageUrl())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MyChannelMemberResponse> findAllParticipateMyInfo(Long memberId) {
+        List<ChannelMember> myChannelMembers = channelMemberRepository.findByMemberId(memberId);
+
+        return myChannelMembers.stream()
+                .map(MemberService::buildChannelMemberResponse)
+                .toList();
+    }
+
+    private static MyChannelMemberResponse buildChannelMemberResponse(ChannelMember channelMember) {
+        return MyChannelMemberResponse.builder()
+                .channelMemberId(channelMember.getId())
+                .channelName(channelMember.getChannel().getName())
+                .codeName(channelMember.getMemberCodeName())
+                .profileImage(channelMember.isUsingDefaultProfile()?
+                        channelMember.getMember().getProfileImageUrl(): channelMember.getProfileImage())
+                .channelId(channelMember.getChannel().getId())
                 .build();
     }
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -44,6 +44,7 @@ create TABLE if not exists `pickitalki`.questions
     created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at     DATETIME              DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted     TINYINT(1)   NOT NULL DEFAULT 0,
+    CONSTRAINT unique_channel_today_question UNIQUE (channel_uuid, created_at),
     FOREIGN KEY (channel_uuid) REFERENCES channels (uuid),
     FOREIGN KEY (author_id) REFERENCES members (id)
 );

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -25,6 +25,8 @@ create TABLE if not exists `pickitalki`.channel_members
     channel_uuid     BINARY(16)  NOT NULL,
     member_id        BIGINT      NOT NULL,
     member_code_name VARCHAR(20),
+    profile_image TEXT NULL,
+    is_using_default_profile TINYINT(1) NOT NULL DEFAULT 1,
     role             VARCHAR(10) NOT NULL,
     created_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at       DATETIME             DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,


### PR DESCRIPTION
## What is this PR? :mag:
- [x] 내 정보 조회(공용 닉네임, 프로필 사진 조회) 
-> "api/members"
- [x] 내가 속한/만든/초대된 채널별 코드명, 프로필 사진 조회 및 수정
-> "/api/members/channelMembers/all" , "/api/members/channelMembers/own", "/api/members/channelMembers/invited"
- [x] 내 친구 조회
-> "/api/members/friends"

## Changes :memo:
도메인 쪽의 변화를 눈여겨 보셔야 합니다.
1. channelMember 도메인에 isUsingDefaultProfile , profileImage 속성 추가
lofi를 보니 채널마다 프로필이미지를 다르게 설정할 수 있도록 기획이 잡혀있는 것 같아 수정했습니다. 

2. Channel 도메인의 getter를 불변객체로 반환
채널멤버에다가 스트림으로 이것저것 필터해서 응답하는 로직이 꽤 있었는데, 이 과정에서 회원을 탈퇴시키거나 하는 일은 없어야 하기 때문에 불변객체로 조회하도록 수정했습니다. 이것이 추후에 전방위적으로 영향을 미칠 수도 있으니 인지해야할 것 같습니다.
```java
    public List<ChannelMember> getChannelMembers() {
        return Collections.unmodifiableList(channelMembers);
    }
```

- todo
오늘의 질문에 걸었던 제약조건이 제대로 구현이 안된 상태입니다. createDate 관련 컬럼과 제약조건 schema.sql에 제대로 되있지 않아 추후 수정이 더 필요합니다.
공용,채널 프로필에 대한 수정 기능도 추후 더 구현해야 합니다.

## Screenshot :camera:
