### PR TITLE
[feat] 채널 초대코드 6자리 숫자로 변경

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -40,6 +40,9 @@ public class Channel extends BaseEntity implements Persistable<String> {
     @Column(nullable = false, length = 10, unique = true)
     private String name;
 
+    @Column(nullable = false, length = 6, unique = true)
+    private String inviteCode;
+
     @OneToMany(mappedBy = "channel", cascade = {PERSIST, MERGE}, fetch = FetchType.LAZY)
     private List<ChannelMember> channelMembers = new ArrayList<>();
 
@@ -51,6 +54,7 @@ public class Channel extends BaseEntity implements Persistable<String> {
     public Channel(UUID uuid, String name) {
         this.uuid = uuid;
         this.name = name;
+        this.inviteCode = InviteCodeGenerator.generateInviteCode(uuid);
     }
 
     public Channel(String name) {

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -106,7 +106,7 @@ public class Channel extends BaseEntity implements Persistable<String> {
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
+        if (obj == null) return false;
 
         Channel other = (Channel) obj;
         return Objects.equals(uuid, other.uuid);

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -17,8 +17,6 @@ import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Objects;
 
 import static java.util.Objects.hash;
@@ -88,12 +86,6 @@ public class ChannelMember extends BaseEntity {
 
     public boolean isSameMember(Long memberId) {
         return Objects.equals(memberId, this.member.getId());
-    }
-
-    public String getInviteCode() {
-        return Base64.getUrlEncoder()
-                .withoutPadding()
-                .encodeToString(this.channel.getUuid().toString().getBytes(StandardCharsets.UTF_8));
     }
 
     public String getProfileImage() {

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelRepository.java
@@ -11,6 +11,8 @@ public interface ChannelRepository extends JpaRepository<Channel,UUID> {
 
     Optional<Channel> findByUuid(UUID uuid);
 
+    Optional<Channel> findByInviteCode(String inviteCode);
+
     Optional<Channel> findByName(String name);
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/InviteCodeGenerator.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/InviteCodeGenerator.java
@@ -1,0 +1,18 @@
+package com.dnd12th_4.pickitalki.domain.channel;
+
+import java.security.SecureRandom;
+import java.util.UUID;
+
+public class InviteCodeGenerator {
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    public static String generateInviteCode(UUID channelUuid) {
+        int randomPart = RANDOM.nextInt(900000) + 100000; // 100000 ~ 999999 (6자리 랜덤)
+        int hashPart = Math.abs(channelUuid.hashCode()) % 1000000; // UUID 해시값 활용
+
+        // 두 숫자를 조합 후 6자리 숫자로 변환
+        int inviteCode = (randomPart + hashPart) % 1_000_000;
+        return String.format("%06d", inviteCode);
+    }
+
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/question/Question.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/question/Question.java
@@ -36,7 +36,7 @@ public class Question extends BaseEntity {
     @JoinColumn(name = "channel_uuid", nullable = false)
     private Channel channel;
 
-    @OneToOne(fetch = FetchType.EAGER)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "channel_member_id", nullable = false)
     private ChannelMember author;
 
@@ -50,7 +50,7 @@ public class Question extends BaseEntity {
     private boolean isAnonymous;
 
     @Column(nullable = true, length = 10)
-    private String authorName;
+    private String anonymousName;
 
     @Column(nullable = false)
     private LocalDate createdDate;
@@ -58,7 +58,7 @@ public class Question extends BaseEntity {
     protected Question() {
     }
 
-    public Question(Long id, Channel channel, ChannelMember author, String content, long questionNumber, boolean isAnonymous, String authorName) {
+    public Question(Long id, Channel channel, ChannelMember author, String content, long questionNumber, boolean isAnonymous, String anonymousName) {
         if (!author.getChannel().equals(channel)) {
             throw new IllegalArgumentException("작성자는 해당 채널의 멤버여야 합니다.");
         }
@@ -68,8 +68,8 @@ public class Question extends BaseEntity {
         this.content = content;
         this.questionNumber = questionNumber;
         this.isAnonymous = isAnonymous;
-        this.authorName = isAnonymous ? authorName : null;
-        validateAuthorName(isAnonymous, authorName);
+        this.anonymousName = isAnonymous ? anonymousName : null;
+        validateAuthorName(isAnonymous, anonymousName);
     }
 
     private void validateAuthorName(boolean isAnonymous, String authorName) {

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/question/QuestionRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/question/QuestionRepository.java
@@ -3,11 +3,13 @@ package com.dnd12th_4.pickitalki.domain.question;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@Repository
 public interface QuestionRepository extends JpaRepository<Question,Long> {
 
     @Query("SELECT COUNT(q) FROM Question q WHERE q.channel.uuid = :channelUuid")

--- a/src/main/java/com/dnd12th_4/pickitalki/presentation/exceptionhandler/ApiExceptionHandler.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/presentation/exceptionhandler/ApiExceptionHandler.java
@@ -4,9 +4,10 @@ import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.presentation.error.ErrorCodeIfs;
 import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import org.springframework.core.annotation.Order;
+import org.springframework.dao.DataAccessException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
@@ -23,6 +24,30 @@ public class ApiExceptionHandler {
                 .status(errorCode.getHttpStatusCode())
                 .body(
                   Api.ERROR(errorCode,apiException.getErrorDescription())
+                );
+    }
+
+    @ExceptionHandler(value = IllegalArgumentException.class)
+    public ResponseEntity<Object> apiException(
+            IllegalArgumentException exception
+    ) {;
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(
+                        exception.getMessage()
+                );
+    }
+
+    @ExceptionHandler(value = DataAccessException.class)
+    public ResponseEntity<Object> databaseException(
+            DataAccessException exception
+    ) {
+
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(
+                        exception.getMessage()
                 );
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
@@ -56,7 +56,7 @@ public class QuestionService {
         return questionRepository.findTodayQuestion(channelUuid)
                 .map(question -> TodayQuestionResponse.builder()
                         .isExist(true)
-                        .writer(question.getAuthorName())
+                        .writer(question.getAnonymousName())
                         .signalCount(question.getQuestionNumber())
                         .time(formatToKoreanTime(question.getCreatedAt()))
                         .content(question.getContent())
@@ -89,7 +89,7 @@ public class QuestionService {
 
         return questions.stream()
                 .map(question -> new QuestionResponse(
-                        question.getAuthorName(),
+                        question.getAnonymousName(),
                         question.getQuestionNumber(),
                         question.getContent(),
                         question.getCreatedAt().toString()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     defer-datasource-initialization: true
     show-sql: true
   sql:
@@ -21,7 +21,6 @@ kakao:
   redirect-uri: "http://ec2-52-79-242-171.ap-northeast-2.compute.amazonaws.com:8080/auth/kakao/callback"
   token-url: "https://kauth.kakao.com/oauth/token"
   user-info-url: "https://kapi.kakao.com/v2/user/me"
-
 
 jwt:
   secret-key: "pikytalk-secure-connection-key-keep-friends-together!"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     defer-datasource-initialization: true
     show-sql: true
   sql:

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -41,16 +41,18 @@ create TABLE if not exists `pickitalki`.questions
 (
     id             BIGINT AUTO_INCREMENT PRIMARY KEY,
     channel_uuid   BINARY(16)   NOT NULL,
-    author_id      BIGINT       NOT NULL,
+    channel_member_id      BIGINT       NOT NULL,
     content        VARCHAR(255) NOT NULL,
+    question_number BIGINT NOT NULL,
     is_anonymous   BOOLEAN      NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(30),
     created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_date   DATE     NOT NULL,
     updated_at     DATETIME     DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted     TINYINT(1)   NOT NULL DEFAULT 0,
-    CONSTRAINT unique_channel_today_question UNIQUE (channel_uuid, created_at),
+    CONSTRAINT unique_channel_today_question UNIQUE (channel_uuid, created_date),
     FOREIGN KEY (channel_uuid) REFERENCES channels (uuid),
-    FOREIGN KEY (author_id) REFERENCES members (id)
+    FOREIGN KEY (channel_member_id) REFERENCES channel_members (id)
 );
 
 create TABLE if not exists `pickitalki`.answers

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -15,10 +15,12 @@ create TABLE if not exists `pickitalki`.channels
 (
     uuid       BINARY(16) PRIMARY KEY,
     name       VARCHAR(30) NOT NULL UNIQUE,
+    invite_code VARCHAR(6) NOT NULL UNIQUE,
     created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME             DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1)  NOT NULL DEFAULT 0
 );
+
 create TABLE if not exists `pickitalki`.channel_members
 (
     id               BIGINT AUTO_INCREMENT PRIMARY KEY,
@@ -44,7 +46,7 @@ create TABLE if not exists `pickitalki`.questions
     is_anonymous   BOOLEAN      NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(30),
     created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at     DATETIME              DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    updated_at     DATETIME     DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted     TINYINT(1)   NOT NULL DEFAULT 0,
     CONSTRAINT unique_channel_today_question UNIQUE (channel_uuid, created_at),
     FOREIGN KEY (channel_uuid) REFERENCES channels (uuid),
@@ -60,7 +62,7 @@ create TABLE if not exists `pickitalki`.answers
     is_anonymous   BOOLEAN      NOT NULL DEFAULT FALSE,
     anonymous_name VARCHAR(10),
     created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at     DATETIME              DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    updated_at     DATETIME     DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted     TINYINT(1)   NOT NULL DEFAULT 0,
     FOREIGN KEY (question_id) REFERENCES questions (id),
     FOREIGN KEY (member_id) REFERENCES members (id)
@@ -72,6 +74,6 @@ CREATE TABLE IF NOT EXISTS tutorial
     member_id  BIGINT      NOT NULL,
     status     VARCHAR(10) NOT NULL,
     created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME             DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    updated_at DATETIME    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     is_deleted TINYINT(1)  NOT NULL DEFAULT 0
 );


### PR DESCRIPTION
## What is this PR? :mag:
1. 기존의 base64기반 초대코드 대신 6자리 숫자의 초대코드를 기획에서 원하셔서 수정
-> 채널에 invite_code라는 콜룸이 생겼고, 초대코드 -> 채널의 조회를 디코딩 기반이 아닌 DB에서의 조회로 수행하기로 바뀜

2. 채널 생성 오류 수정
schema.sql 의 questions 에 대한 ddl문을 제대로 정의하지 않아 생성시 오류가 발생했었음. 이를 수정 

3. 채널의 동등성 (equals) 비교가 잘 안되던 오류 수정
equals에서 클래스 비교문을 삭제함

## Changes :memo:


