### PR TITLE
채널멤버의 포인트와 레벨 조회 기능, 질문의 수정,삭제 기능

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/common/config/WebConfig.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/config/WebConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -40,5 +41,11 @@ public class WebConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
 
         resolvers.add(memberIdResolver);
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/images/**")
+                .addResourceLocations("file:/app/images/");
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/common/config/WebConfig.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/config/WebConfig.java
@@ -34,7 +34,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(jwtInterceptor)
                 .addPathPatterns("/**")
-                .excludePathPatterns("/auth/**","/public/**","/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html","/hello/**");
+                .excludePathPatterns("/images/**", "/auth/**","/public/**","/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html","/hello/**");
     }
 
     @Override

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -6,6 +6,7 @@ import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelCreateRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelJoinResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberStatusResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelSpecificResponse;
@@ -74,8 +75,18 @@ public class ChannelController {
         );
     }
 
+    @GetMapping("/{channelId}/members/status")
+    public Api<ChannelMemberStatusResponse> findChannelMemberStatus(
+            @MemberId Long memberId,
+            @PathVariable("channelId") String channelId
+    ) {
+        ChannelMemberStatusResponse channelMemberStatus = channelService.findChannelMemberStatus(memberId, channelId);
+
+        return Api.OK(channelMemberStatus);
+    }
+
     @GetMapping("/inviteCode")
-    public ResponseEntity<InviteCodeDto> getChannelInviteCode(
+    public ResponseEntity<InviteCodeDto> findChannelInviteCode(
             @MemberId Long memberId,
             @RequestParam("channelName") @Valid String channelName
     ) {

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberStatusResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberStatusResponse.java
@@ -1,0 +1,8 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ChannelMemberStatusResponse(String channelName, int countPerson, long channelMemberId, String codeName,
+                                          int level, int point, int todayAnswerCount, String characterImageUri) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/QuestionController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/QuestionController.java
@@ -4,16 +4,21 @@ import com.dnd12th_4.pickitalki.common.annotation.MemberId;
 import com.dnd12th_4.pickitalki.controller.question.dto.QuestionCreateRequest;
 import com.dnd12th_4.pickitalki.controller.question.dto.QuestionCreateResponse;
 import com.dnd12th_4.pickitalki.controller.question.dto.QuestionResponse;
+import com.dnd12th_4.pickitalki.controller.question.dto.QuestionUpdateRequest;
+import com.dnd12th_4.pickitalki.controller.question.dto.QuestionUpdateResponse;
 import com.dnd12th_4.pickitalki.controller.question.dto.TodayQuestionResponse;
 import com.dnd12th_4.pickitalki.service.question.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -41,6 +46,17 @@ public class QuestionController {
                 );
     }
 
+    @GetMapping
+    public ResponseEntity<QuestionResponse> findTodayQuestionByChannel(
+            @MemberId Long memberId,
+            @RequestParam("questionId") long questionId
+    ) {
+        QuestionResponse questionResponse = questionService.findQuestionById(memberId, questionId);
+
+        return ResponseEntity.ok()
+                .body(questionResponse);
+    }
+
     @GetMapping("/today")
     public ResponseEntity<TodayQuestionResponse> findTodayQuestionByChannel(
             @MemberId Long memberId,
@@ -61,6 +77,26 @@ public class QuestionController {
 
         return ResponseEntity.ok()
                 .body(questionResponses);
+    }
+
+    @PutMapping("/{questionId}")
+    public ResponseEntity<QuestionUpdateResponse> updateQuestion(
+            @MemberId Long memberId,
+            @RequestBody QuestionUpdateRequest request
+    ) {
+        QuestionUpdateResponse questionUpdateResponse = questionService.updateQuestion(memberId, request.questionId(), request.content());
+
+        return ResponseEntity.ok()
+                .body(questionUpdateResponse);
+    }
+
+    @DeleteMapping("/{questionId}")
+    public ResponseEntity<Void> deleteQuestion(
+            @MemberId Long memberId,
+            @PathVariable("questionId") Long questionId
+    ) {
+        questionService.deleteQuestion(memberId, questionId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionResponse.java
@@ -1,4 +1,7 @@
 package com.dnd12th_4.pickitalki.controller.question.dto;
 
+import lombok.Builder;
+
+@Builder
 public record QuestionResponse(String writerName, long signalNumber, String content, String createdAt) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionUpdateRequest.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.dnd12th_4.pickitalki.controller.question.dto;
+
+public record QuestionUpdateRequest(long questionId, String content) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionUpdateResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionUpdateResponse.java
@@ -1,0 +1,7 @@
+package com.dnd12th_4.pickitalki.controller.question.dto;
+
+import lombok.Builder;
+
+@Builder
+public record QuestionUpdateResponse(long questionId) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -28,6 +28,8 @@ import static java.util.Objects.isNull;
 @SuperBuilder
 public class ChannelMember extends BaseEntity {
 
+    public static final int LEVEL_GAGE = 100;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -37,17 +39,20 @@ public class ChannelMember extends BaseEntity {
     private Channel channel;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id" ,nullable = false)
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(name = "member_code_name", nullable=true)
+    @Column(name = "member_code_name", nullable = true)
     private String memberCodeName;
 
-    @Column(name = "profile_image", nullable=true)
+    @Column(name = "profile_image", nullable = true)
     private String profileImage;
 
     @Column(name = "is_using_default_profile", nullable = false)
     private boolean isUsingDefaultProfile = true;
+
+    @Column(name = "point", nullable = false)
+    private int point;
 
     @Column(columnDefinition = "varchar(10)", nullable = false)
     @Enumerated(EnumType.STRING)
@@ -56,18 +61,23 @@ public class ChannelMember extends BaseEntity {
     protected ChannelMember() {
     }
 
-    public ChannelMember(Channel channel, Member member, String memberCodeName, Role role) {
+    public ChannelMember(Channel channel, Member member, String memberCodeName, int point, Role role) {
         validateChannel(channel);
         this.channel = channel;
         this.member = member;
         this.memberCodeName = memberCodeName;
         this.isUsingDefaultProfile = true;
         this.profileImage = null;
+        this.point = point;
         this.role = role;
     }
 
+    public ChannelMember(Channel channel, Member member, String memberCodeName, Role role) {
+        this(channel, member, memberCodeName, 0, role);
+    }
+
     public ChannelMember(Channel channel, Member member, Role role) {
-        this(channel, member, null, role);
+        this(channel, member, null, 0, role);
     }
 
     private void validateChannel(Channel channel) {
@@ -93,6 +103,14 @@ public class ChannelMember extends BaseEntity {
             return member.getProfileImageUrl();
         }
         return profileImage;
+    }
+
+    public int getLevel() {
+        return point / LEVEL_GAGE;
+    }
+
+    public int getPoint() {
+        return point % LEVEL_GAGE;
     }
 
     public void setCustomProfileImage(String profileImage) {

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -29,6 +29,7 @@ import static java.util.Objects.isNull;
 public class ChannelMember extends BaseEntity {
 
     public static final int LEVEL_GAGE = 100;
+    public static final int QUESTION_CREATE_POINT = 10;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -106,11 +107,15 @@ public class ChannelMember extends BaseEntity {
     }
 
     public int getLevel() {
-        return point / LEVEL_GAGE;
+        return (point / LEVEL_GAGE) + 1;
     }
 
     public int getPoint() {
         return point % LEVEL_GAGE;
+    }
+
+    public void risePoint() {
+        point += QUESTION_CREATE_POINT;
     }
 
     public void setCustomProfileImage(String profileImage) {

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberLevel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberLevel.java
@@ -1,0 +1,27 @@
+package com.dnd12th_4.pickitalki.domain.channel;
+
+import java.util.Arrays;
+
+public enum ChannelMemberLevel {
+    LV1(1, "level1.png"),
+    LV2(2, "level2.png"),
+    LV3(3, "level3.png"),
+    LV4(4, "level4.png"),
+    LV5(5, "level5.png");
+
+    private final int level;
+    private final String imageUrl;
+
+    ChannelMemberLevel(int level, String imageUrl) {
+        this.level = level;
+        this.imageUrl = imageUrl;
+    }
+
+    public static String getImageByLevel(int memberLevel) {
+        return Arrays.stream(ChannelMemberLevel.values())
+                .filter(lv -> lv.level == memberLevel)
+                .findFirst()
+                .map(lv -> "/static/images/" + lv.imageUrl)
+                .orElse("/static/images/default.png");
+    }
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/question/Question.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/question/Question.java
@@ -38,7 +38,7 @@ public class Question extends BaseEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "channel_member_id", nullable = false)
-    private ChannelMember author;
+    private ChannelMember writer;
 
     @Column(nullable = false, length = 100)
     private String content;
@@ -58,13 +58,13 @@ public class Question extends BaseEntity {
     protected Question() {
     }
 
-    public Question(Long id, Channel channel, ChannelMember author, String content, long questionNumber, boolean isAnonymous, String anonymousName) {
-        if (!author.getChannel().equals(channel)) {
+    public Question(Long id, Channel channel, ChannelMember writer, String content, long questionNumber, boolean isAnonymous, String anonymousName) {
+        if (!writer.getChannel().equals(channel)) {
             throw new IllegalArgumentException("작성자는 해당 채널의 멤버여야 합니다.");
         }
         this.id = id;
         this.channel = channel;
-        this.author = author;
+        this.writer = writer;
         this.content = content;
         this.questionNumber = questionNumber;
         this.isAnonymous = isAnonymous;
@@ -77,13 +77,24 @@ public class Question extends BaseEntity {
             throw new IllegalArgumentException("질문을 생성할 수 없습니다. 익명 질문은 반드시 익명 닉네임으로 작성해야 합니다.");
         }
 
-        if (!isAnonymous && !author.getMemberCodeName().equals(authorName)) {
+        if (!isAnonymous && !writer.getMemberCodeName().equals(authorName)) {
             throw new IllegalArgumentException("질문을 생성할 수 없습니다. 실명 질문은 반드시 채널의 코드네임으로 작성해야 합니다.");
         }
     }
 
-    public Question(Channel channel, ChannelMember author, String content, long questionNumber, boolean isAnonymous, String anonymousName) {
-        this(null, channel, author, content, questionNumber, isAnonymous, anonymousName);
+    public Question(Channel channel, ChannelMember writer, String content, long questionNumber, boolean isAnonymous, String anonymousName) {
+        this(null, channel, writer, content, questionNumber, isAnonymous, anonymousName);
+    }
+
+    public String getWriterName() {
+        if (isAnonymous) {
+            return anonymousName;
+        }
+        return writer.getMemberCodeName();
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
     }
 
     @PrePersist

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -114,9 +114,9 @@ public class ChannelService {
         Channel channel = channelMember.getChannel();
 
         String ownerName = channel.getChannelMembers().stream()
-                .filter(it -> it.getRole() == Role.OWNER && it.getChannel().equals(channel))
+                .filter(it -> it.getRole() == Role.OWNER && it.getChannel().getUuid().equals(channel.getUuid()))
                 .findAny()
-                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "buildChannelShowAllResponse DB 튜플이 없습니다"))
+                .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "해당 채널의 owner를 찾을 수 없습니다"))
                 .getMemberCodeName();
 
         long signalCount = questionRepository.countByChannelUuid(channel.getUuid());

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -3,12 +3,14 @@ package com.dnd12th_4.pickitalki.service.channel;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelJoinResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberStatusResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelSpecificResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.MemberCodeNameResponse;
 import com.dnd12th_4.pickitalki.domain.channel.Channel;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
+import com.dnd12th_4.pickitalki.domain.channel.ChannelMemberLevel;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMemberRepository;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelRepository;
 import com.dnd12th_4.pickitalki.domain.channel.Role;
@@ -200,6 +202,26 @@ public class ChannelService {
                 .channelRoomName(channel.getName())
                 .countPerson((long) channel.getChannelMembers().size())
                 .signalCount(signalCount)
+                .build();
+
+    }
+
+    public ChannelMemberStatusResponse findChannelMemberStatus(Long memberId, String channelId) {
+        UUID channelUuid = UUID.fromString(channelId);
+        Channel channel = channelRepository.findByUuid(channelUuid)
+                .orElseThrow(() -> new IllegalArgumentException("해당 채널을 찾을 수 없습니다. 채널의 회원 상태정보를 응답할 수 없습니다."));
+        ChannelMember channelMember = channel.findChannelMemberById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("채널에 해당 회원이 존재하지 않습니다. 채널의 회원 상태정보를 조회할 권한이 없습니다."));
+
+        return ChannelMemberStatusResponse.builder()
+                .channelName(channel.getName())
+                .countPerson(channel.getChannelMembers().size())
+                .codeName(channelMember.getMemberCodeName())
+                .channelMemberId(channelMember.getId())
+                .level(channelMember.getLevel())
+                .point(channelMember.getPoint())
+                .todayAnswerCount(0) //답변 pr 머지후 구현 예정
+                .characterImageUri(ChannelMemberLevel.getImageByLevel(channelMember.getLevel()))
                 .build();
 
     }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
@@ -43,6 +43,7 @@ public class QuestionService {
                 new Question(channel, channelMember, content, questionCount+1, isAnonymous,
                         isAnonymous ? anonymousName : channelMember.getMemberCodeName())
         );
+        channelMember.risePoint();
 
         return question.getId();
     }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
@@ -1,6 +1,7 @@
 package com.dnd12th_4.pickitalki.service.question;
 
 import com.dnd12th_4.pickitalki.controller.question.dto.QuestionResponse;
+import com.dnd12th_4.pickitalki.controller.question.dto.QuestionUpdateResponse;
 import com.dnd12th_4.pickitalki.controller.question.dto.TodayQuestionResponse;
 import com.dnd12th_4.pickitalki.domain.channel.Channel;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
@@ -40,7 +41,7 @@ public class QuestionService {
         long questionCount = questionRepository.countByChannelUuid(channelUuid);
 
         Question question = questionRepository.save(
-                new Question(channel, channelMember, content, questionCount+1, isAnonymous,
+                new Question(channel, channelMember, content, questionCount + 1, isAnonymous,
                         isAnonymous ? anonymousName : channelMember.getMemberCodeName())
         );
         channelMember.risePoint();
@@ -48,6 +49,7 @@ public class QuestionService {
         return question.getId();
     }
 
+    @Transactional(readOnly = true)
     public TodayQuestionResponse findTodayQuestion(Long memberId, String channelId) {
         UUID channelUuid = UUID.fromString(channelId);
         Channel channel = channelRepository.findByUuid(channelUuid)
@@ -57,7 +59,7 @@ public class QuestionService {
         return questionRepository.findTodayQuestion(channelUuid)
                 .map(question -> TodayQuestionResponse.builder()
                         .isExist(true)
-                        .writer(question.getAnonymousName())
+                        .writer(question.getWriterName())
                         .signalCount(question.getQuestionNumber())
                         .time(formatToKoreanTime(question.getCreatedAt()))
                         .content(question.getContent())
@@ -80,6 +82,7 @@ public class QuestionService {
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
     }
 
+    @Transactional(readOnly = true)
     public List<QuestionResponse> findByChannelId(Long memberId, String channelId) {
         UUID channelUuid = UUID.fromString(channelId);
         Channel channel = channelRepository.findByUuid(channelUuid)
@@ -90,11 +93,50 @@ public class QuestionService {
 
         return questions.stream()
                 .map(question -> new QuestionResponse(
-                        question.getAnonymousName(),
+                        question.getWriterName(),
                         question.getQuestionNumber(),
                         question.getContent(),
                         question.getCreatedAt().toString()
                 ))
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public QuestionResponse findQuestionById(Long memberId, Long questionId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 질문을 찾을 수 없습니다."));
+        question.getChannel().findChannelMemberById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 질문을 읽을 수 있는 회원이 아닙니다. 이 질문의 채널에 참여해야합니다."));
+
+        return QuestionResponse.builder()
+                .writerName(question.getWriterName())
+                .signalNumber(question.getQuestionNumber())
+                .content(question.getContent())
+                .createdAt(question.getCreatedAt().toString())
+                .build();
+    }
+
+    public QuestionUpdateResponse updateQuestion(Long memberId, Long questionId, String content) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 질문을 찾을 수 없습니다. 질문을 수정할 수 없습니다."));
+        if (!question.getWriter().isSameMember(memberId)) {
+            throw new IllegalArgumentException("해당 질문을 수정할 권한이 없습니다.");
+        }
+
+        question.updateContent(content);
+
+        return QuestionUpdateResponse.builder()
+                .questionId(question.getId())
+                .build();
+    }
+
+    public void deleteQuestion(Long memberId, Long questionId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 질문을 찾을 수 없습니다. 질문을 삭제할 수 없습니다."));
+        if (!question.getWriter().isSameMember(memberId)) {
+            throw new IllegalArgumentException("해당 질문을 삭제할 권한이 없습니다.");
+        }
+
+        questionRepository.delete(question);
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -29,6 +29,7 @@ create TABLE if not exists `pickitalki`.channel_members
     member_code_name VARCHAR(20),
     profile_image TEXT NULL,
     is_using_default_profile TINYINT(1) NOT NULL DEFAULT 1,
+    point INT NOT NULL DEFAULT 0,
     role             VARCHAR(10) NOT NULL,
     created_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at       DATETIME             DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,


### PR DESCRIPTION
## What is this PR? :mag:
- 포인트 기능 추가
채널멤버 도메인에 point 속성 추가. 레벨은 기본 경험지한계인 100으로 나눠서 구함.
질문 생성 시에 point+10하는 로직 추가
레벨에 따라 토키 이미지 반환하는 로직 추가

** 더 해야할 것: 채널멤버가 오늘 몇 개의 답변을 했는지(오늘의 응답) 정보 답변 PR머지 이후 구현필요.

- 질문의 수정,삭제 기능 추가 

## Changes :memo:

## Screenshot :camera:
