### PR TITLE
[Feat] 프로필 이미지 업로드 기능 + 회원의 닉네임,프로필이미지 변경 기능

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/common/config/AppConfig.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/config/AppConfig.java
@@ -1,5 +1,6 @@
 package com.dnd12th_4.pickitalki.common.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -7,8 +8,15 @@ import org.springframework.web.client.RestTemplate;
 @Configuration
 public class AppConfig {
 
+    @Value("${app.base-url}")
+    private String baseUrl;
+
     @Bean
     public RestTemplate restTemplate(){
         return new RestTemplate();
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/answer/AnswerController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/answer/AnswerController.java
@@ -7,7 +7,7 @@ import com.dnd12th_4.pickitalki.controller.answer.dto.response.AnswerShowAllResp
 import com.dnd12th_4.pickitalki.controller.answer.dto.response.AnswerWriteResponse;
 import com.dnd12th_4.pickitalki.controller.answer.dto.response.AnswerUpdateResponse;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
-import com.dnd12th_4.pickitalki.service.service.AnswerService;
+import com.dnd12th_4.pickitalki.service.answer.AnswerService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
@@ -2,14 +2,15 @@ package com.dnd12th_4.pickitalki.controller.member;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
+import com.dnd12th_4.pickitalki.controller.member.dto.ChannelFriendResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.MemberResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.MyChannelMemberResponse;
 import com.dnd12th_4.pickitalki.domain.member.Member;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.login.MemberService;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/ProfileImageController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/ProfileImageController.java
@@ -1,0 +1,34 @@
+package com.dnd12th_4.pickitalki.controller.member;
+
+import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.controller.member.dto.ImageResponse;
+import com.dnd12th_4.pickitalki.service.login.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members/profile-image")
+public class ProfileImageController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<ImageResponse> uploadProfileImage(
+            @MemberId Long memberId,
+            @RequestParam("file") MultipartFile file
+    ) {
+        ImageResponse imageResponse = memberService.uploadProfileImage(memberId, file);
+
+        return ResponseEntity.status(CREATED)
+                .body(imageResponse);
+    }
+}
+

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/ProfileImageController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/ProfileImageController.java
@@ -2,10 +2,14 @@ package com.dnd12th_4.pickitalki.controller.member;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
 import com.dnd12th_4.pickitalki.controller.member.dto.ImageResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.MemberResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.MemberUpdateRequest;
 import com.dnd12th_4.pickitalki.service.login.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,5 +34,17 @@ public class ProfileImageController {
         return ResponseEntity.status(CREATED)
                 .body(imageResponse);
     }
+
+    @PatchMapping
+    public ResponseEntity<MemberResponse> updateMemberProfile(
+            @MemberId Long memberId,
+            @RequestBody MemberUpdateRequest request
+    ) {
+        MemberResponse memberResponse = memberService.updateMemberProfile(memberId, request.nickName(), request.image());
+
+        return ResponseEntity.status(CREATED)
+                .body(memberResponse);
+    }
+
 }
 

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/ChannelFriendResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/ChannelFriendResponse.java
@@ -1,4 +1,4 @@
-package com.dnd12th_4.pickitalki.controller.member;
+package com.dnd12th_4.pickitalki.controller.member.dto;
 
 import lombok.Builder;
 

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/ImageResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/ImageResponse.java
@@ -1,0 +1,7 @@
+package com.dnd12th_4.pickitalki.controller.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ImageResponse(String imageUrl, long memberId) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/MemberResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/MemberResponse.java
@@ -1,4 +1,4 @@
-package com.dnd12th_4.pickitalki.controller.member;
+package com.dnd12th_4.pickitalki.controller.member.dto;
 
 import lombok.Builder;
 

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/MemberUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.dnd12th_4.pickitalki.controller.member.dto;
+
+public record MemberUpdateRequest(String nickName, String image) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/MyChannelMemberResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/MyChannelMemberResponse.java
@@ -1,4 +1,4 @@
-package com.dnd12th_4.pickitalki.controller.member;
+package com.dnd12th_4.pickitalki.controller.member.dto;
 
 import lombok.Builder;
 

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberLevel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMemberLevel.java
@@ -21,7 +21,7 @@ public enum ChannelMemberLevel {
         return Arrays.stream(ChannelMemberLevel.values())
                 .filter(lv -> lv.level == memberLevel)
                 .findFirst()
-                .map(lv -> "/static/images/" + lv.imageUrl)
-                .orElse("/static/images/default.png");
+                .map(lv -> "/images/" + lv.imageUrl)
+                .orElse("/images/default.png");
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
@@ -16,6 +16,8 @@ import lombok.experimental.SuperBuilder;
 import java.util.ArrayList;
 import java.util.List;
 
+import static io.micrometer.common.util.StringUtils.isBlank;
+
 @Getter
 @SuperBuilder
 @Entity
@@ -56,6 +58,9 @@ public class Member extends BaseEntity {
     }
 
     public void setNickName(String nickName) {
+        if (isBlank(nickName)) {
+            throw new IllegalArgumentException("이름을 변경할 수 없습니다. 1글자 이상의 이름만 설정가능합니다.");
+        }
         this.nickName = nickName;
     }
 
@@ -64,6 +69,9 @@ public class Member extends BaseEntity {
     }
 
     public void setProfileImageUrl(String imageUrl) {
+        if (isBlank(imageUrl)) {
+            throw new IllegalArgumentException("프로필 이미지를 변경할 수 없습니다. 유효하지 않은 이미지입니다.");
+        }
         this.profileImageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/member/Member.java
@@ -63,4 +63,7 @@ public class Member extends BaseEntity {
         this.refreshToken = refreshToken;
     }
 
+    public void setProfileImageUrl(String imageUrl) {
+        this.profileImageUrl = imageUrl;
+    }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/presentation/exceptionhandler/ApiExceptionHandler.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/presentation/exceptionhandler/ApiExceptionHandler.java
@@ -66,6 +66,6 @@ public class ApiExceptionHandler {
                 .body(
                         exception.getMessage()
                 );
-
     }
+
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/presentation/exceptionhandler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/presentation/exceptionhandler/GlobalExceptionHandler.java
@@ -2,18 +2,16 @@ package com.dnd12th_4.pickitalki.presentation.exceptionhandler;
 
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
-import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 @Order(value = Integer.MAX_VALUE)
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(value = ApiException.class)
+    @ExceptionHandler(value = Exception.class)
     public ResponseEntity<Api<Object>> exception(
             Exception exception
     ){

--- a/src/main/java/com/dnd12th_4/pickitalki/service/answer/AnswerService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/answer/AnswerService.java
@@ -1,4 +1,4 @@
-package com.dnd12th_4.pickitalki.service.service;
+package com.dnd12th_4.pickitalki.service.answer;
 
 import com.dnd12th_4.pickitalki.controller.answer.dto.request.AnswerRequest;
 import com.dnd12th_4.pickitalki.controller.answer.dto.request.AnswerUpdateRequest;
@@ -128,10 +128,8 @@ public class AnswerService {
         List<AnswerResponse> answers = question.getAnswerList()
                 .stream()
                 .filter(it -> it.isDeleted() == false)
-                .map(answer -> {
-
-                    return getAnswerResponse(answer, memberId);
-                }).toList();
+                .map(answer -> getAnswerResponse(answer, memberId))
+                .toList();
 
         return AnswerShowAllResponse.builder()
                 .signalCount(answers.size())
@@ -154,9 +152,8 @@ public class AnswerService {
         List<AnswerResponse> answers = question.getAnswerList()
                 .stream()
                 .filter(it -> it.isDeleted() == false)
-                .map(answer -> {
-                    return getAnswerResponse(answer, channelMember.getMember().getId());
-                }).toList();
+                .map(answer -> getAnswerResponse(answer, channelMember.getMember().getId()))
+                .toList();
 
         return new AnswerWriteResponse(nowSignal, nowAuthor, nowContent, answers);
     }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
@@ -2,16 +2,15 @@ package com.dnd12th_4.pickitalki.service.login;
 
 
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelControllerEnums;
-import com.dnd12th_4.pickitalki.controller.member.ChannelFriendResponse;
-import com.dnd12th_4.pickitalki.controller.member.MemberResponse;
-import com.dnd12th_4.pickitalki.controller.member.MyChannelMemberResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.ChannelFriendResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.MemberResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.MyChannelMemberResponse;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMemberRepository;
 import com.dnd12th_4.pickitalki.domain.channel.Role;
 import com.dnd12th_4.pickitalki.domain.member.Member;
 import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
 import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
-import com.dnd12th_4.pickitalki.presentation.error.MemberErrorCode;
 import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,4 +30,4 @@ jwt:
   refresh-token-expiration : 604800000 # 7?
 
 app:
-  base-url: "http://ec2-52-79-242-171.ap-northeast-2.compute.amazonaws.com:8080/api/images/profiles/"
+  base-url: "http://ec2-52-79-242-171.ap-northeast-2.compute.amazonaws.com:8080"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,3 +29,5 @@ jwt:
   access-expiration-time: 1800000  # 24?? (???)
   refresh-token-expiration : 604800000 # 7?
 
+app:
+  base-url: "http://ec2-52-79-242-171.ap-northeast-2.compute.amazonaws.com:8080/api/images/profiles/"


### PR DESCRIPTION
## What is this PR? :mag:
1. 프로필 이미지 업로드 기능
이미지 변경 전에 먼저 프론트에서 이미지를 서버에 업로드 후, url을 받아서 그 url로 프로필을 변경합니다.
2.회원의 닉네임, 프로필이미지 변경 기능 

**채널 회원에 대한 프로필 이미지는 아직 구현하지 않음**
**실제 배포된 서버에서는 권한 문제 등이 발생할 수 있어서 실환경에서 테스트해보아야 함** 
## Changes :memo:

## Screenshot :camera:
로컬에서는 정상동작함
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/af001bf1-6c0b-4b71-bf87-320f52f889e6" />
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/660a0ee8-c718-41e7-bcb7-459e2d345890" />

