### PR TITLE
[feat] 채널 포인트,캐릭터 조회 기능 + 채널에서의 탈퇴,삭제 기능 

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/common/config/AppConfig.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/config/AppConfig.java
@@ -9,14 +9,14 @@ import org.springframework.web.client.RestTemplate;
 public class AppConfig {
 
     @Value("${app.base-url}")
-    private String baseUrl;
+    private static String baseUrl;
 
     @Bean
     public RestTemplate restTemplate(){
         return new RestTemplate();
     }
 
-    public String getBaseUrl() {
+    public static String getBaseUrl() {
         return baseUrl;
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -2,17 +2,14 @@ package com.dnd12th_4.pickitalki.controller.channel;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelCreateRequest;
+import com.dnd12th_4.pickitalki.controller.channel.dto.InviteCodeDto;
+import com.dnd12th_4.pickitalki.controller.channel.dto.InviteRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;
-import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberResponse;
-
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberStatusResponse;
-
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelSpecificResponse;
-import com.dnd12th_4.pickitalki.controller.channel.dto.InviteCodeDto;
-import com.dnd12th_4.pickitalki.controller.channel.dto.InviteRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.MemberCodeNameResponse;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.channel.ChannelService;
@@ -71,13 +68,9 @@ public class ChannelController {
             @MemberId Long memberId,
             @PathVariable("channelId") String channelId
     ) {
-        List<ChannelMemberDto> channelMembers = channelService.findChannelMembers(memberId, channelId);
+        ChannelMemberResponse channelMemberResponse = channelService.findChannelMembers(memberId, channelId);
 
-        return Api.OK(ChannelMemberResponse.builder()
-                .memberCount(channelMembers.size())
-                .channelMembers(channelMembers)
-                .build()
-        );
+        return Api.OK(channelMemberResponse);
     }
 
     @GetMapping("/{channelId}/members/status")

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums.INVITEDALL;
 import static com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums.MADEALL;
 import static com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums.SHOWALL;
+import static java.util.Comparator.comparing;
 
 
 @RestController
@@ -92,7 +93,8 @@ public class ChannelController {
     @GetMapping("/channel-profile")
     public Api<List<ChannelShowAllResponse>> findChannelsByRole(
             @MemberId Long memberId,
-            @RequestParam("tab") String channelFilter
+            @RequestParam("tab") String channelFilter,
+            @RequestParam(value = "sort", defaultValue = "latest") String sort
     ) {
         ChannelControllerEnums channelEnum;
         if (channelFilter.equals("all")) {
@@ -104,7 +106,17 @@ public class ChannelController {
         } else {
             throw new IllegalArgumentException("지원하지 않는 파라미터입니다. all, my-channel, invited-channel 중 1개를 요청헤주세요");
         }
+
         List<ChannelShowAllResponse> channelShowAllResponses = channelService.findAllMyChannels(memberId, channelEnum);
+
+        if (sort.equals("latest")) {
+            channelShowAllResponses.sort(comparing(ChannelShowAllResponse::getCreatedAt).reversed());
+        } else if (sort.equals("oldest")) {
+            channelShowAllResponses.sort(comparing(ChannelShowAllResponse::getCreatedAt));
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 정렬 기준입니다. latest 또는 oldest 중 1개를 요청해주세요.");
+        }
+
         return Api.OK(channelShowAllResponses);
     }
 

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -107,8 +108,13 @@ public class ChannelController {
         return Api.OK(channelShowAllResponses);
     }
 
+    @DeleteMapping("/{channelId}")
+    public ResponseEntity<String> deleteChannel(
+            @MemberId Long memberId,
+            @PathVariable("channelId") String channelId
+    ) {
+        channelService.deleteChannel(memberId, channelId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }
-
-
-
-

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -2,17 +2,11 @@ package com.dnd12th_4.pickitalki.controller.channel;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelCreateRequest;
-import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberUpdateRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.InviteCodeDto;
-import com.dnd12th_4.pickitalki.controller.channel.dto.InviteRequest;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelSpecificResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelStatusResponse;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.MemberCodeNameResponse;
-import com.dnd12th_4.pickitalki.controller.member.dto.MyChannelMemberResponse;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.channel.ChannelService;
 import jakarta.validation.Valid;
@@ -20,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -54,37 +47,6 @@ public class ChannelController {
                 .body(channelResponse);
     }
 
-    @PatchMapping("/{channelId}/codeName")
-    public Api<MemberCodeNameResponse> updateMemberCodeName(
-            @MemberId Long memberId,
-            @PathVariable("channelId") String channelId,
-            @RequestParam("codeName") @Valid String codeName
-    ) {
-        MemberCodeNameResponse memberCodeNameResponse = channelService.updateCodeName(memberId, channelId, codeName);
-
-        return Api.OK(memberCodeNameResponse);
-    }
-
-    @GetMapping("/{channelId}/members")
-    public Api<ChannelMemberResponse> findChannelMembers(
-            @MemberId Long memberId,
-            @PathVariable("channelId") String channelId
-    ) {
-        ChannelMemberResponse channelMemberResponse = channelService.findChannelMembers(memberId, channelId);
-
-        return Api.OK(channelMemberResponse);
-    }
-
-    @PatchMapping("/{channelId}/members/profile")
-    public Api<MyChannelMemberResponse> updateChannelMemberProfile(
-            @MemberId Long memberId,
-            @PathVariable("channelId") String channelId,
-            @RequestBody ChannelMemberUpdateRequest request
-    ) {
-        MyChannelMemberResponse myChannelMemberResponse = channelService.updateChannelMemberProfile(memberId, channelId, request.codeName(), request.image());
-
-        return Api.OK(myChannelMemberResponse);
-    }
 
     @GetMapping("/{channelId}/status")
     public Api<ChannelStatusResponse> findChannelStatus(
@@ -104,16 +66,6 @@ public class ChannelController {
     ) {
         String inviteCode = channelService.findInviteCode(memberId, channelName);
         return ResponseEntity.ok(new InviteCodeDto(inviteCode));
-    }
-
-    @PostMapping("/join")
-    public Api<ChannelJoinResponse> joinMemberToChannel(
-            @MemberId Long memberId,
-            @RequestBody InviteRequest joinRequest
-    ) {
-        ChannelJoinResponse channelJoinResponse = channelService.joinMember(memberId, joinRequest.inviteCode(), joinRequest.codeName());
-
-        return Api.OK(channelJoinResponse);
     }
 
     @GetMapping

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -2,15 +2,17 @@ package com.dnd12th_4.pickitalki.controller.channel;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelCreateRequest;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberUpdateRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.InviteCodeDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.InviteRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberResponse;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelStatusResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelSpecificResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelStatusResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.MemberCodeNameResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.MyChannelMemberResponse;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.channel.ChannelService;
 import jakarta.validation.Valid;
@@ -71,6 +73,17 @@ public class ChannelController {
         ChannelMemberResponse channelMemberResponse = channelService.findChannelMembers(memberId, channelId);
 
         return Api.OK(channelMemberResponse);
+    }
+
+    @PatchMapping("/{channelId}/members/profile")
+    public Api<MyChannelMemberResponse> updateChannelMemberProfile(
+            @MemberId Long memberId,
+            @PathVariable("channelId") String channelId,
+            @RequestBody ChannelMemberUpdateRequest request
+    ) {
+        MyChannelMemberResponse myChannelMemberResponse = channelService.updateChannelMemberProfile(memberId, channelId, request.codeName(), request.image());
+
+        return Api.OK(myChannelMemberResponse);
     }
 
     @GetMapping("/{channelId}/status")

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -6,7 +6,7 @@ import com.dnd12th_4.pickitalki.controller.channel.dto.InviteCodeDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.InviteRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberResponse;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberStatusResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelStatusResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelSpecificResponse;
@@ -73,14 +73,14 @@ public class ChannelController {
         return Api.OK(channelMemberResponse);
     }
 
-    @GetMapping("/{channelId}/members/status")
-    public Api<ChannelMemberStatusResponse> findChannelMemberStatus(
+    @GetMapping("/{channelId}/status")
+    public Api<ChannelStatusResponse> findChannelStatus(
             @MemberId Long memberId,
             @PathVariable("channelId") String channelId
     ) {
-        ChannelMemberStatusResponse channelMemberStatus = channelService.findChannelMemberStatus(memberId, channelId);
+        ChannelStatusResponse channelStatus = channelService.findChannelStatus(memberId, channelId);
 
-        return Api.OK(channelMemberStatus);
+        return Api.OK(channelStatus);
     }
 
 

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelMemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelMemberController.java
@@ -1,0 +1,96 @@
+package com.dnd12th_4.pickitalki.controller.channel;
+
+import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberUpdateRequest;
+import com.dnd12th_4.pickitalki.controller.channel.dto.InviteRequest;
+import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.response.MemberCodeNameResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.MyChannelMemberResponse;
+import com.dnd12th_4.pickitalki.presentation.api.Api;
+import com.dnd12th_4.pickitalki.service.channel.ChannelService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/channels")
+public class ChannelMemberController {
+
+    private final ChannelService channelService;
+
+    @PatchMapping("/{channelId}/codeName")
+    public Api<MemberCodeNameResponse> updateMemberCodeName(
+            @MemberId Long memberId,
+            @PathVariable("channelId") String channelId,
+            @RequestParam("codeName") @Valid String codeName
+    ) {
+        MemberCodeNameResponse memberCodeNameResponse = channelService.updateCodeName(memberId, channelId, codeName);
+
+        return Api.OK(memberCodeNameResponse);
+    }
+
+    @GetMapping("/{channelId}/members")
+    public Api<ChannelMemberResponse> findChannelMembers(
+            @MemberId Long memberId,
+            @PathVariable("channelId") String channelId
+    ) {
+        ChannelMemberResponse channelMemberResponse = channelService.findChannelMembers(memberId, channelId);
+
+        return Api.OK(channelMemberResponse);
+    }
+
+    @PatchMapping("/{channelId}/members/profile")
+    public Api<MyChannelMemberResponse> updateChannelMemberProfile(
+            @MemberId Long memberId,
+            @PathVariable("channelId") String channelId,
+            @RequestBody ChannelMemberUpdateRequest request
+    ) {
+        MyChannelMemberResponse myChannelMemberResponse = channelService.updateChannelMemberProfile(memberId, channelId, request.codeName(), request.image());
+
+        return Api.OK(myChannelMemberResponse);
+    }
+
+
+    @PostMapping("/join")
+    public Api<ChannelJoinResponse> joinMemberToChannel(
+            @MemberId Long memberId,
+            @RequestBody InviteRequest joinRequest
+    ) {
+        ChannelJoinResponse channelJoinResponse = channelService.joinMember(memberId, joinRequest.inviteCode(), joinRequest.codeName());
+
+        return Api.OK(channelJoinResponse);
+    }
+
+    @DeleteMapping("/members")
+    public ResponseEntity<String> leaveChannels(
+            @MemberId Long memberId,
+            @RequestBody ChannelMemberDeleteRequest request
+    ) {
+        channelService.leaveChannels(memberId, request.channelIds());
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/{channelId}/members")
+    public ResponseEntity<String> leaveOneChannel(
+            @MemberId Long memberId,
+            @PathVariable("channelId") String channelId
+    ) {
+        channelService.leaveChannel(memberId, channelId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+}
+

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelMemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelMemberController.java
@@ -1,6 +1,7 @@
 package com.dnd12th_4.pickitalki.controller.channel;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDeleteRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberUpdateRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.InviteRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelMemberDeleteRequest.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelMemberDeleteRequest.java
@@ -1,0 +1,6 @@
+package com.dnd12th_4.pickitalki.controller.channel;
+
+import java.util.List;
+
+public record ChannelMemberDeleteRequest(List<String> channelIds) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberDeleteRequest.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberDeleteRequest.java
@@ -1,4 +1,4 @@
-package com.dnd12th_4.pickitalki.controller.channel;
+package com.dnd12th_4.pickitalki.controller.channel.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberUpdateRequest.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/ChannelMemberUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto;
+
+public record ChannelMemberUpdateRequest(String codeName, String image) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelMemberResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelMemberResponse.java
@@ -6,5 +6,5 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record ChannelMemberResponse(long memberCount, List<ChannelMemberDto> channelMembers) {
+public record ChannelMemberResponse(String channelName, long memberCount, List<ChannelMemberDto> channelMembers) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelMemberStatusResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelMemberStatusResponse.java
@@ -1,8 +1,0 @@
-package com.dnd12th_4.pickitalki.controller.channel.dto.response;
-
-import lombok.Builder;
-
-@Builder
-public record ChannelMemberStatusResponse(String channelName, int countPerson, long channelMemberId, String codeName,
-                                          int level, int point, int todayAnswerCount, String characterImageUri) {
-}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelShowAllResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelShowAllResponse.java
@@ -17,4 +17,5 @@ public class ChannelShowAllResponse {
     private Long countPerson;
     private Long signalCount;
     private String inviteCode;
+    private String createdAt;
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelStatusResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelStatusResponse.java
@@ -1,0 +1,7 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record ChannelStatusResponse(String channelName, String channelId, int level, int point, String characterImageUri) {
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/KakaoConfig.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/KakaoConfig.java
@@ -1,4 +1,4 @@
-package com.dnd12th_4.pickitalki.controller.login.dto;
+package com.dnd12th_4.pickitalki.controller.login;
 
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -68,7 +68,7 @@ public class Channel extends BaseEntity implements Persistable<String> {
         this(UUID.randomUUID(), name, 0);
     }
 
-    public void joinChannelMember(ChannelMember channelMember){
+    public void joinChannelMember(ChannelMember channelMember) {
         validateChannelMember(channelMember);
         channelMembers.add(channelMember);
     }
@@ -82,6 +82,12 @@ public class Channel extends BaseEntity implements Persistable<String> {
                 .anyMatch(ch -> ch.isSameMember(channelMember.getMember().getId()));
         if (isAlreadyExist) {
             throw new IllegalArgumentException("이미 해당 채널에 존재하는 회원입니다.");
+        }
+    }
+
+    public void leaveChannel(ChannelMember channelMember) {
+        if (!channelMembers.remove(channelMember)) {
+            throw new IllegalArgumentException("해당 채널에 존재하지 않는 회원입니다. 탈퇴할 수 없습니다.");
         }
     }
 
@@ -130,4 +136,5 @@ public class Channel extends BaseEntity implements Persistable<String> {
         Channel other = (Channel) obj;
         return Objects.equals(uuid, other.uuid);
     }
+
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -32,6 +32,9 @@ import static java.util.Objects.isNull;
 @SuperBuilder
 public class Channel extends BaseEntity implements Persistable<String> {
 
+    public static final int LEVEL_GAGE = 100;
+    public static final int QUESTION_CREATE_POINT = 10;
+
     @Id
     @JdbcTypeCode(SqlTypes.BINARY)
     @Column(columnDefinition = "BINARY(16)")
@@ -43,6 +46,9 @@ public class Channel extends BaseEntity implements Persistable<String> {
     @Column(nullable = false, length = 6, unique = true)
     private String inviteCode;
 
+    @Column(name = "point", nullable = false)
+    private int point;
+
     @OneToMany(mappedBy = "channel", cascade = {PERSIST, MERGE}, fetch = FetchType.LAZY)
     private List<ChannelMember> channelMembers = new ArrayList<>();
 
@@ -51,14 +57,15 @@ public class Channel extends BaseEntity implements Persistable<String> {
 
     protected Channel() {}
 
-    public Channel(UUID uuid, String name) {
+    public Channel(UUID uuid, String name, int point) {
         this.uuid = uuid;
         this.name = name;
+        this.point = point;
         this.inviteCode = InviteCodeGenerator.generateInviteCode(uuid);
     }
 
     public Channel(String name) {
-        this(UUID.randomUUID(), name);
+        this(UUID.randomUUID(), name, 0);
     }
 
     public void joinChannelMember(ChannelMember channelMember){
@@ -86,6 +93,18 @@ public class Channel extends BaseEntity implements Persistable<String> {
 
     public List<ChannelMember> getChannelMembers() {
         return Collections.unmodifiableList(channelMembers);
+    }
+
+    public int getLevel() {
+        return (point / LEVEL_GAGE) + 1;
+    }
+
+    public int getPoint() {
+        return point % LEVEL_GAGE;
+    }
+
+    public void risePoint() {
+        point += QUESTION_CREATE_POINT;
     }
 
     @Override

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelLevel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelLevel.java
@@ -2,7 +2,7 @@ package com.dnd12th_4.pickitalki.domain.channel;
 
 import java.util.Arrays;
 
-public enum ChannelMemberLevel {
+public enum ChannelLevel {
     LV1(1, "level1.png"),
     LV2(2, "level2.png"),
     LV3(3, "level3.png"),
@@ -12,13 +12,13 @@ public enum ChannelMemberLevel {
     private final int level;
     private final String imageUrl;
 
-    ChannelMemberLevel(int level, String imageUrl) {
+    ChannelLevel(int level, String imageUrl) {
         this.level = level;
         this.imageUrl = imageUrl;
     }
 
     public static String getImageByLevel(int memberLevel) {
-        return Arrays.stream(ChannelMemberLevel.values())
+        return Arrays.stream(ChannelLevel.values())
                 .filter(lv -> lv.level == memberLevel)
                 .findFirst()
                 .map(lv -> "/images/" + lv.imageUrl)

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -29,9 +29,6 @@ import static java.util.Objects.isNull;
 @SuperBuilder
 public class ChannelMember extends BaseEntity {
 
-    public static final int LEVEL_GAGE = 100;
-    public static final int QUESTION_CREATE_POINT = 10;
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -58,10 +55,6 @@ public class ChannelMember extends BaseEntity {
     private boolean isUsingDefaultProfile = true;
 
 
-    @Column(name = "point", nullable = false)
-    private int point;
-
-
     @Column(columnDefinition = "varchar(10)", nullable = false)
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -69,25 +62,18 @@ public class ChannelMember extends BaseEntity {
     protected ChannelMember() {
     }
 
-    public ChannelMember(Channel channel, Member member, String memberCodeName, int point, Role role) {
+    public ChannelMember(Channel channel, Member member, String memberCodeName, Role role) {
         validateChannel(channel);
         this.channel = channel;
         this.member = member;
         this.memberCodeName = memberCodeName;
         this.isUsingDefaultProfile = true;
         this.profileImage = null;
-
-        this.point = point;
-
         this.role = role;
     }
 
-    public ChannelMember(Channel channel, Member member, String memberCodeName, Role role) {
-        this(channel, member, memberCodeName, 0, role);
-    }
-
     public ChannelMember(Channel channel, Member member, Role role) {
-        this(channel, member, null, 0, role);
+        this(channel, member, null, role);
     }
 
     private void validateChannel(Channel channel) {
@@ -106,18 +92,6 @@ public class ChannelMember extends BaseEntity {
 
     public boolean isSameMember(Long memberId) {
         return Objects.equals(memberId, this.member.getId());
-    }
-
-    public int getLevel() {
-        return (point / LEVEL_GAGE) + 1;
-    }
-
-    public int getPoint() {
-        return point % LEVEL_GAGE;
-    }
-
-    public void risePoint() {
-        point += QUESTION_CREATE_POINT;
     }
 
     public String getProfileImage() {

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -114,7 +114,7 @@ public class ChannelMember extends BaseEntity {
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
-        if (obj == null || getClass() != obj.getClass()) return false;
+        if (obj == null) return false;
 
         ChannelMember other = (ChannelMember) obj;
         return Objects.equals(id, other.id);

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/question/QuestionRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/question/QuestionRepository.java
@@ -23,8 +23,12 @@ public interface QuestionRepository extends JpaRepository<Question,Long> {
 
     Optional<Question> findByIdAndIsDeletedFalse(Long id);
 
-    List<Question> findByChannelUuidAndIsDeletedFalseOrderByCreatedAtAsc(UUID channelUuid);
+    List<Question> findByChannel_UuidAndIsDeletedFalseOrderByCreatedAtAsc(UUID channelUuid);
+    List<Question> findByChannel_UuidAndIsDeletedFalseOrderByCreatedAtDesc(UUID channelUuid);
 
+    List<Question> findByWriter_Member_IdAndIsDeletedFalseOrderByCreatedAtDesc(Long memberId);
+
+    List<Question> findByWriter_Member_IdAndIsDeletedFalseOrderByCreatedAtAsc(Long memberId);
 
 }
 

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums.INVITEDALL;
 import static com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums.MADEALL;
@@ -109,7 +110,7 @@ public class ChannelService {
                         (status == MADEALL && channelMember.getRole() == Role.OWNER)
                 )
                 .map(this::buildChannelShowAllResponse)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     private ChannelShowAllResponse buildChannelShowAllResponse(ChannelMember channelMember) {

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -131,6 +131,7 @@ public class ChannelService {
                 .countPerson((long) channel.getChannelMembers().size())
                 .signalCount(signalCount)
                 .inviteCode(channel.getInviteCode())
+                .createdAt(channel.getCreatedAt().toString())
                 .build();
     }
 

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -3,6 +3,7 @@ package com.dnd12th_4.pickitalki.service.channel;
 import com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberStatusResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelShowAllResponse;
@@ -169,20 +170,26 @@ public class ChannelService {
     }
 
     @Transactional(readOnly= true)
-    public List<ChannelMemberDto> findChannelMembers(Long memberId, String channelId) {
+    public ChannelMemberResponse findChannelMembers(Long memberId, String channelId) {
         UUID channelUuid = UUID.fromString(channelId);
         Channel channel = channelRepository.findByUuid(channelUuid)
                 .orElseThrow(() -> new IllegalArgumentException("해당 채널을 찾을 수 없습니다. 채널의 회원정보를 응답할 수 없습니다."));
         channel.findChannelMemberById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("채널에 해당 회원이 존재하지 않습니다. 채널의 회원정보들을 조회할 권한이 없습니다."));
 
-        return channel.getChannelMembers()
+        List<ChannelMemberDto> channelMemberDtos = channel.getChannelMembers()
                 .stream().map(channelMember -> ChannelMemberDto.builder()
                         .nickName(channelMember.getMemberCodeName())
                         .profileImageUrl(channelMember.getMember().getProfileImageUrl())
                         .channelMemberId(channelMember.getId())
                         .build()
                 ).toList();
+
+        return ChannelMemberResponse.builder()
+                .channelMembers(channelMemberDtos)
+                .channelName(channel.getName())
+                .memberCount(channelMemberDtos.size())
+                .build();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -34,6 +34,7 @@ import static com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums
 import static com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums.SHOWALL;
 import static io.micrometer.common.util.StringUtils.isBlank;
 
+@Transactional
 @Service
 @RequiredArgsConstructor
 public class ChannelService {
@@ -257,5 +258,21 @@ public class ChannelService {
                 .codeName(channelMember.getMemberCodeName())
                 .profileImage(channelMember.getProfileImage())
                 .build();
+    }
+
+    public void leaveChannel(Long memberId, String channelId) {
+        UUID channelUuid = UUID.fromString(channelId);
+        Channel channel = channelRepository.findByUuid(channelUuid)
+                .orElseThrow(() -> new IllegalArgumentException("해당 채널을 찾을 수 없습니다. 탈퇴할 수 없습니다."));
+        ChannelMember channelMember = channel.findChannelMemberById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 채널에 참여해 있지 않습니다. 탈퇴할 수 없습니다."));
+
+        channel.leaveChannel(channelMember);
+    }
+
+    public void leaveChannels(Long memberId, List<String> channelIds) {
+        for (String channelId : channelIds) {
+            leaveChannel(memberId, channelId);
+        }
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -275,4 +275,18 @@ public class ChannelService {
             leaveChannel(memberId, channelId);
         }
     }
+
+    public void deleteChannel(Long memberId, String channelId) {
+        UUID channelUuid = UUID.fromString(channelId);
+        Channel channel = channelRepository.findByUuid(channelUuid)
+                .orElseThrow(() -> new IllegalArgumentException("해당 채널을 찾을 수 없습니다. 탈퇴할 수 없습니다."));
+        ChannelMember channelMember = channel.findChannelMemberById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 채널에 참여해 있지 않습니다. 탈퇴할 수 없습니다."));
+
+        if (channelMember.getRole() != Role.OWNER) {
+            throw new IllegalArgumentException("채널의 개설자가 아닙니다. 채널을 삭제할 권한이 없습니다.");
+        }
+
+        channelRepository.deleteById(channelUuid);
+    }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -1,5 +1,6 @@
 package com.dnd12th_4.pickitalki.service.channel;
 
+import com.dnd12th_4.pickitalki.common.config.AppConfig;
 import com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;
@@ -232,7 +233,7 @@ public class ChannelService {
                 .channelId(channel.getId())
                 .level(channel.getLevel())
                 .point(channel.getPoint())
-                .characterImageUri(ChannelLevel.getImageByLevel(channel.getLevel()))
+                .characterImageUri(AppConfig.getBaseUrl()+ChannelLevel.getImageByLevel(channel.getLevel()))
                 .build();
         //TODO 멤버의 조회 시에 오늘 채널 몇개 중에 몇개의 응답을 했는지 정보 반환하는 api필요
     }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -4,14 +4,14 @@ import com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberResponse;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberStatusResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelStatusResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelShowAllResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelSpecificResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.MemberCodeNameResponse;
 import com.dnd12th_4.pickitalki.domain.channel.Channel;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
-import com.dnd12th_4.pickitalki.domain.channel.ChannelMemberLevel;
+import com.dnd12th_4.pickitalki.domain.channel.ChannelLevel;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMemberRepository;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelRepository;
 import com.dnd12th_4.pickitalki.domain.channel.Role;
@@ -91,7 +91,6 @@ public class ChannelService {
         channelMember = channelMemberRepository.save(channelMember);
 
         return new ChannelJoinResponse(channel.getId(), channel.getName(), channelMember.getMemberCodeName());
-
 
     }
 
@@ -218,22 +217,20 @@ public class ChannelService {
                 .build();
     }
 
-    public ChannelMemberStatusResponse findChannelMemberStatus(Long memberId, String channelId) {
+    public ChannelStatusResponse findChannelStatus(Long memberId, String channelId) {
         UUID channelUuid = UUID.fromString(channelId);
         Channel channel = channelRepository.findByUuid(channelUuid)
-                .orElseThrow(() -> new IllegalArgumentException("해당 채널을 찾을 수 없습니다. 채널의 회원 상태정보를 응답할 수 없습니다."));
-        ChannelMember channelMember = channel.findChannelMemberById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("채널에 해당 회원이 존재하지 않습니다. 채널의 회원 상태정보를 조회할 권한이 없습니다."));
+                .orElseThrow(() -> new IllegalArgumentException("해당 채널을 찾을 수 없습니다. 채널의 상태정보를 응답할 수 없습니다."));
+        channel.findChannelMemberById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("채널에 해당 회원이 존재하지 않습니다. 채널의 상태정보를 조회할 권한이 없습니다."));
 
-        return ChannelMemberStatusResponse.builder()
+        return ChannelStatusResponse.builder()
                 .channelName(channel.getName())
-                .countPerson(channel.getChannelMembers().size())
-                .codeName(channelMember.getMemberCodeName())
-                .channelMemberId(channelMember.getId())
-                .level(channelMember.getLevel())
-                .point(channelMember.getPoint())
-                .todayAnswerCount(0) //답변 pr 머지후 구현 예정
-                .characterImageUri(ChannelMemberLevel.getImageByLevel(channelMember.getLevel()))
+                .channelId(channel.getId())
+                .level(channel.getLevel())
+                .point(channel.getPoint())
+                .characterImageUri(ChannelLevel.getImageByLevel(channel.getLevel()))
                 .build();
+        //TODO 멤버의 조회 시에 오늘 채널 몇개 중에 몇개의 응답을 했는지 정보 반환하는 api필요
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/tool/HttpCreator.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/tool/HttpCreator.java
@@ -1,14 +1,11 @@
 package com.dnd12th_4.pickitalki.service.login.tool;
 
-import com.dnd12th_4.pickitalki.controller.login.dto.KakaoConfig;
+import com.dnd12th_4.pickitalki.controller.login.KakaoConfig;
 import com.dnd12th_4.pickitalki.presentation.error.TokenErrorCode;
 import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;

--- a/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
@@ -37,7 +37,6 @@ public class QuestionService {
 
         Channel channel = channelRepository.findByUuid(channelUuid)
                 .orElseThrow(() -> new IllegalArgumentException("해당하는 채널을 찾을 수 없습니다. 새 시그널을 생성할 수 없습니다."));
-
         ChannelMember channelMember = channel.findChannelMemberById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("채널에 해당 회원이 존재하지 않습니다. 질문을 생성할 권한이 없습니다."));
         long questionCount = questionRepository.countByChannelUuid(channelUuid);
@@ -46,7 +45,7 @@ public class QuestionService {
                 new Question(channel, channelMember, content, questionCount + 1, isAnonymous,
                         isAnonymous ? anonymousName : channelMember.getMemberCodeName())
         );
-        channelMember.risePoint();
+        channel.risePoint();
 
         return question.getId();
     }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
@@ -1,9 +1,7 @@
 package com.dnd12th_4.pickitalki.service.question;
 
 import com.dnd12th_4.pickitalki.controller.question.dto.QuestionResponse;
-
 import com.dnd12th_4.pickitalki.controller.question.dto.QuestionUpdateResponse;
-
 import com.dnd12th_4.pickitalki.controller.question.dto.TodayQuestionResponse;
 import com.dnd12th_4.pickitalki.domain.channel.Channel;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
@@ -84,13 +82,20 @@ public class QuestionService {
     }
 
     @Transactional(readOnly = true)
-    public List<QuestionResponse> findByChannelId(Long memberId, String channelId) {
+    public List<QuestionResponse> findByChannelId(Long memberId, String channelId, String sort) {
         UUID channelUuid = UUID.fromString(channelId);
         Channel channel = channelRepository.findByUuid(channelUuid)
                 .orElseThrow(() -> new IllegalArgumentException("해당 채널이 존재하지 않습니다. 오늘의 시그널 정보를 찾을 수 없습니다."));
         validateMemberInChannel(channel, memberId);
 
-        List<Question> questions = questionRepository.findByChannelUuidAndIsDeletedFalseOrderByCreatedAtAsc(channelUuid);
+        List<Question> questions;
+        if (sort.equals("latest")) {
+            questions = questionRepository.findByChannel_UuidAndIsDeletedFalseOrderByCreatedAtDesc(channelUuid);
+        } else if (sort.equals("oldest")) {
+            questions = questionRepository.findByChannel_UuidAndIsDeletedFalseOrderByCreatedAtAsc(channelUuid);
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 정렬 기준입니다. latest 또는 oldest 중 1개를 요청해주세요.");
+        }
 
         return questions.stream()
                 .map(question -> new QuestionResponse(
@@ -140,5 +145,27 @@ public class QuestionService {
 
         question.softDelete();
 
+    }
+
+    @Transactional(readOnly = true)
+    public List<QuestionResponse> findQuestionsByMember(Long memberId, String sort) {
+        List<Question> questions;
+
+        if (sort.equals("latest")) {
+            questions = questionRepository.findByWriter_Member_IdAndIsDeletedFalseOrderByCreatedAtDesc(memberId);
+        } else if (sort.equals("oldest")) {
+            questions = questionRepository.findByWriter_Member_IdAndIsDeletedFalseOrderByCreatedAtAsc(memberId);
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 정렬 기준입니다. latest 또는 oldest 중 하나를 사용해주세요.");
+        }
+
+        return questions.stream()
+                .map(q -> QuestionResponse.builder()
+                        .writerName(q.getWriterName())
+                        .signalNumber(q.getQuestionNumber())
+                        .content(q.getContent())
+                        .createdAt(q.getCreatedAt().toString())
+                        .build())
+                .toList();
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -7,7 +7,7 @@ create TABLE if not exists `pickitalki`.members
     profile_image_url TEXT          NULL,
     refresh_token     TEXT          NULL,
     created_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        DATETIME               DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    updated_at        DATETIME      DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted        TINYINT(1)    NOT NULL DEFAULT 0
 );
 
@@ -15,10 +15,10 @@ create TABLE if not exists `pickitalki`.channels
 (
     uuid       BINARY(16) PRIMARY KEY,
     name       VARCHAR(30) NOT NULL UNIQUE,
-
     invite_code VARCHAR(6) NOT NULL UNIQUE,
+    point INT NOT NULL DEFAULT 0,
     created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME             DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    updated_at DATETIME    DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted TINYINT(1)  NOT NULL DEFAULT 0
 );
 
@@ -30,12 +30,9 @@ create TABLE if not exists `pickitalki`.channel_members
     member_code_name VARCHAR(20),
     profile_image TEXT NULL,
     is_using_default_profile TINYINT(1) NOT NULL DEFAULT 1,
-
-    point INT NOT NULL DEFAULT 0,
-
     role             VARCHAR(10) NOT NULL,
     created_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at       DATETIME             DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    updated_at       DATETIME    DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
     is_deleted       TINYINT(1)  NOT NULL DEFAULT 0,
     FOREIGN KEY (channel_uuid) REFERENCES channels (uuid),
     FOREIGN KEY (member_id) REFERENCES members (id)
@@ -70,7 +67,6 @@ create TABLE if not exists `pickitalki`.answers
     anonymous_name VARCHAR(10),
     created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at     DATETIME     DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-
     is_deleted     TINYINT(1)   NOT NULL DEFAULT 0,
     FOREIGN KEY (question_id) REFERENCES questions (id),
     FOREIGN KEY (member_id) REFERENCES members (id)


### PR DESCRIPTION
## What is this PR? :mag:
channelController 의 메서드가 많아지는 것 같아
channelController + ChannelMemberController로 분리했습니다. 

- 채널 포인트,캐릭터 조회 기능 
 -> GET /api/channels/{channelId}/status. 

- 채널에서 탈퇴 
DELETE "/api/channels/members"  :  requestBody안의 채널id 들에 대한 탈퇴 
DELETE "/api/channels/{channelId}/members"  path의 채널id에 대한 탍토;

- 채널 삭제 기능 
권한이 Owner여야 가능하도록 구현
DELETE /api/channels/{channelId} : 해당 채널 아예 삭제(폭파) 

이외에 아래의 작업도 했습니다.
- get [/api/channels/{channelId}/members] 응답에 channelName도 포함 
- 채널의 프로필 정보 수정 기능 (채널 프로필, 코드네임)  

TODO: 현재 쿼리들이 soft delete를 적용하지 않은 상태입니다. 기능구현이 끝난 후 일괄적으로 soft delete에 맞게 수정하는 것이 나을 것 같아 일단 적용하지 않았습니다.
## Changes :memo:

## Screenshot :camera:
