### PR TITLE
[feat] 모든 여러개 조회 api에 페이지네이션 구현 완료

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/ChannelController.java
@@ -1,33 +1,20 @@
 package com.dnd12th_4.pickitalki.controller.channel;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.common.dto.request.PageParamRequest;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelCreateRequest;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;
+import com.dnd12th_4.pickitalki.controller.channel.dto.response.*;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberResponse;
 
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelMemberStatusResponse;
-
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelResponse;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelShowAllResponse;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelSpecificResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.InviteCodeDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.InviteRequest;
-import com.dnd12th_4.pickitalki.controller.channel.dto.response.MemberCodeNameResponse;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.channel.ChannelService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -68,16 +55,17 @@ public class ChannelController {
 
     @GetMapping("/{channelId}/members")
     public Api<ChannelMemberResponse> findChannelMembers(
+            @ModelAttribute PageParamRequest pageParamRequest,
             @MemberId Long memberId,
             @PathVariable("channelId") String channelId
     ) {
-        List<ChannelMemberDto> channelMembers = channelService.findChannelMembers(memberId, channelId);
+        ChannelMemberResponse channelMemberResponse = channelService.findChannelMembers(memberId, channelId, pageParamRequest);
 
-        return Api.OK(ChannelMemberResponse.builder()
-                .memberCount(channelMembers.size())
-                .channelMembers(channelMembers)
-                .build()
-        );
+        return Api.OK(channelMemberResponse);
+//                .memberCount(channelMembers.size())
+//                .channelMembers(channelMembers)
+//                .build()
+
     }
 
     @GetMapping("/{channelId}/members/status")
@@ -131,7 +119,8 @@ public class ChannelController {
     }
 
     @GetMapping("/channel-profile")
-    public Api<List<ChannelShowAllResponse>> findChannelsByRole(
+    public Api<ChannelShowAllResponse> findChannelsByRole(
+            @ModelAttribute PageParamRequest pageParamRequest,
             @MemberId Long memberId,
             @RequestParam("tab") String channelFilter
     ) {
@@ -145,8 +134,8 @@ public class ChannelController {
         } else {
             throw new IllegalArgumentException("지원하지 않는 파라미터입니다. all, my-channel, invited-channel 중 1개를 요청헤주세요");
         }
-        List<ChannelShowAllResponse> channelShowAllResponses = channelService.findAllMyChannels(memberId, channelEnum);
-        return Api.OK(channelShowAllResponses);
+        ChannelShowAllResponse channelShowAllResponse =  channelService.findAllMyChannels(memberId, channelEnum, pageParamRequest);
+        return Api.OK(channelShowAllResponse);
     }
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelMemberResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelMemberResponse.java
@@ -1,10 +1,12 @@
 package com.dnd12th_4.pickitalki.controller.channel.dto.response;
 
+import com.dnd12th_4.pickitalki.common.dto.request.PageParamRequest;
+import com.dnd12th_4.pickitalki.common.dto.response.PageParamResponse;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
-public record ChannelMemberResponse(long memberCount, List<ChannelMemberDto> channelMembers) {
+public record ChannelMemberResponse(long memberCount, List<ChannelMemberDto> channelMembers, PageParamResponse pageParamResponse) {
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelShowAllResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelShowAllResponse.java
@@ -1,9 +1,12 @@
 package com.dnd12th_4.pickitalki.controller.channel.dto.response;
 
+import com.dnd12th_4.pickitalki.common.dto.response.PageParamResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -11,10 +14,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ChannelShowAllResponse {
 
-    private String channelId;
-    private String channelRoomName;
-    private String channelOwnerName;
-    private Long countPerson;
-    private Long signalCount;
-    private String inviteCode;
+    private List<ChannelShowResponse> channelShowResponse;
+    private PageParamResponse pageParamResponse;
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelShowResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/channel/dto/response/ChannelShowResponse.java
@@ -1,0 +1,20 @@
+package com.dnd12th_4.pickitalki.controller.channel.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChannelShowResponse {
+
+    private String channelId;
+    private String channelRoomName;
+    private String channelOwnerName;
+    private Long countPerson;
+    private Long signalCount;
+    private String inviteCode;
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/MemberController.java
@@ -1,20 +1,16 @@
 package com.dnd12th_4.pickitalki.controller.member;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
+import com.dnd12th_4.pickitalki.common.dto.request.PageParamRequest;
 import com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums;
-import com.dnd12th_4.pickitalki.controller.member.dto.ChannelFriendResponse;
-import com.dnd12th_4.pickitalki.controller.member.dto.MemberResponse;
-import com.dnd12th_4.pickitalki.controller.member.dto.MyChannelMemberResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.*;
 import com.dnd12th_4.pickitalki.domain.member.Member;
 import com.dnd12th_4.pickitalki.presentation.api.Api;
 import com.dnd12th_4.pickitalki.service.login.MemberService;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springdoc.core.converters.ModelConverterRegistrar;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,6 +24,7 @@ import static com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums
 public class MemberController {
 
     private final MemberService memberService;
+    private final ModelConverterRegistrar modelConverterRegistrar;
 
     @PostMapping("/name")
     public Api<String> registerName(
@@ -49,7 +46,8 @@ public class MemberController {
     }
 
     @GetMapping("/channel-members")
-    public Api<List<MyChannelMemberResponse>> findMyChannelMemberInfo(
+    public Api<MyChannelMemberShowAllResponse> findMyChannelMemberInfo(
+            @ModelAttribute PageParamRequest pageParamRequest,
             @MemberId Long memberId,
             @RequestParam("tab") String channelFilter
     ) {
@@ -64,18 +62,19 @@ public class MemberController {
             throw new IllegalArgumentException("지원하지 않는 파라미터입니다. all, my-channel, invited-channel 중 1개를 요청헤주세요");
         }
 
-        List<MyChannelMemberResponse> allParticipateMyInfo = memberService.findAllChannelMyInfo(memberId, channelEnum);
+        MyChannelMemberShowAllResponse myChannelMemberShowAllResponse = memberService.findAllChannelMyInfo(memberId, channelEnum, pageParamRequest);
 
-        return Api.OK(allParticipateMyInfo);
+        return Api.OK(myChannelMemberShowAllResponse);
     }
 
     @GetMapping("/friends")
-    public Api<List<ChannelFriendResponse>> findMyFriends(
+    public Api<ChannelFriendShowAllResponse> findMyFriends(
+            @ModelAttribute PageParamRequest pageParamRequest,
             @MemberId Long memberId
     ) {
-        List<ChannelFriendResponse> channelFriends = memberService.findChannelFriends(memberId);
+        ChannelFriendShowAllResponse channelFriendShowAllResponse = memberService.findChannelFriends(memberId, pageParamRequest);
 
-        return Api.OK(channelFriends);
+        return Api.OK(channelFriendShowAllResponse);
     }
 
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/ChannelFriendShowAllResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/ChannelFriendShowAllResponse.java
@@ -1,0 +1,20 @@
+package com.dnd12th_4.pickitalki.controller.member.dto;
+
+import com.dnd12th_4.pickitalki.common.dto.response.PageParamResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChannelFriendShowAllResponse {
+
+    private List<ChannelFriendResponse> channelFriendResponseList;
+
+    private PageParamResponse pageParamResponse;
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/MyChannelMemberShowAllResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/member/dto/MyChannelMemberShowAllResponse.java
@@ -1,0 +1,20 @@
+package com.dnd12th_4.pickitalki.controller.member.dto;
+
+import com.dnd12th_4.pickitalki.common.dto.response.PageParamResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MyChannelMemberShowAllResponse {
+
+    private List<MyChannelMemberResponse> myChannelMemberResponse;
+
+    private PageParamResponse pageParamResponse;
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/QuestionController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/QuestionController.java
@@ -1,27 +1,14 @@
 package com.dnd12th_4.pickitalki.controller.question;
 
 import com.dnd12th_4.pickitalki.common.annotation.MemberId;
-import com.dnd12th_4.pickitalki.controller.question.dto.QuestionCreateRequest;
-import com.dnd12th_4.pickitalki.controller.question.dto.QuestionCreateResponse;
-import com.dnd12th_4.pickitalki.controller.question.dto.QuestionResponse;
+import com.dnd12th_4.pickitalki.common.dto.request.PageParamRequest;
+import com.dnd12th_4.pickitalki.controller.question.dto.*;
 
-import com.dnd12th_4.pickitalki.controller.question.dto.QuestionUpdateRequest;
-import com.dnd12th_4.pickitalki.controller.question.dto.QuestionUpdateResponse;
-
-import com.dnd12th_4.pickitalki.controller.question.dto.TodayQuestionResponse;
 import com.dnd12th_4.pickitalki.service.question.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -72,14 +59,15 @@ public class QuestionController {
     }
 
     @GetMapping("/all")
-    public ResponseEntity<List<QuestionResponse>> findQuestionsByChannel(
+    public ResponseEntity<QuestionShowAllResponse> findQuestionsByChannel(
+            @ModelAttribute PageParamRequest pageParamRequest,
             @MemberId Long memberId,
             @PathVariable("channelId") String channelId
     ) {
-        List<QuestionResponse> questionResponses = questionService.findByChannelId(memberId, channelId);
+        QuestionShowAllResponse questionShowAllResponse = questionService.findByChannelId(memberId, channelId, pageParamRequest);
 
         return ResponseEntity.ok()
-                .body(questionResponses);
+                .body(questionShowAllResponse);
     }
 
     @PutMapping("/{questionId}")

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionShowAllResponse.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/question/dto/QuestionShowAllResponse.java
@@ -1,0 +1,20 @@
+package com.dnd12th_4.pickitalki.controller.question.dto;
+
+import com.dnd12th_4.pickitalki.common.dto.response.PageParamResponse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class QuestionShowAllResponse {
+
+    private List<QuestionResponse> questionResponse;
+
+    private PageParamResponse pageParamResponse;
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/question/QuestionRepository.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/question/QuestionRepository.java
@@ -1,5 +1,7 @@
 package com.dnd12th_4.pickitalki.domain.question;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,8 +25,7 @@ public interface QuestionRepository extends JpaRepository<Question,Long> {
 
     Optional<Question> findByIdAndIsDeletedFalse(Long id);
 
-    List<Question> findByChannelUuidAndIsDeletedFalseOrderByCreatedAtAsc(UUID channelUuid);
-
+    Page<Question> findByChannelUuidAndIsDeletedFalseOrderByCreatedAtAsc(UUID channelUuid, Pageable pageable);
 
 }
 

--- a/src/main/java/com/dnd12th_4/pickitalki/service/answer/AnswerService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/answer/AnswerService.java
@@ -55,15 +55,13 @@ public class AnswerService {
     }
 
     @Transactional
-    public AnswerShowAllResponse showAnswers(Long questionId, Long memberId,PageParamRequest pageParamRequest) {
+    public AnswerShowAllResponse showAnswers(Long questionId, Long memberId,Pageable pageable) {
         Question question = questionRepository.findById(questionId)
                 .orElseThrow(() -> new ApiException(AnswerErrorCode.INVALID_ARGUMENT, "answer save 실패"));
         memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApiException(MemberErrorCode.INVALID_ARGUMENT, "AnswerResponse save 에서 member찾기 실패"));
 
-        Pageable pageable = PageRequest.of(pageParamRequest.getPage(), pageParamRequest.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<Answer> answerPage = answerRepository.findByQuestionIdAndIsDeletedFalse(questionId,pageable);
-
 
         AnswerShowAllResponse answerShowAllResponse = toAnswerInfoResponse(question, memberId, answerPage);
 

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/MemberService.java
@@ -2,11 +2,11 @@ package com.dnd12th_4.pickitalki.service.login;
 
 
 import com.dnd12th_4.pickitalki.common.config.AppConfig;
+import com.dnd12th_4.pickitalki.common.dto.request.PageParamRequest;
+import com.dnd12th_4.pickitalki.common.dto.response.PageParamResponse;
 import com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums;
-import com.dnd12th_4.pickitalki.controller.member.dto.ChannelFriendResponse;
-import com.dnd12th_4.pickitalki.controller.member.dto.ImageResponse;
-import com.dnd12th_4.pickitalki.controller.member.dto.MemberResponse;
-import com.dnd12th_4.pickitalki.controller.member.dto.MyChannelMemberResponse;
+import com.dnd12th_4.pickitalki.controller.member.dto.*;
+import com.dnd12th_4.pickitalki.domain.answer.Answer;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMember;
 import com.dnd12th_4.pickitalki.domain.channel.ChannelMemberRepository;
 import com.dnd12th_4.pickitalki.domain.channel.Role;
@@ -16,6 +16,7 @@ import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
 import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -54,10 +55,11 @@ public class MemberService {
     }
 
     @Transactional(readOnly = true)
-    public List<MyChannelMemberResponse> findAllChannelMyInfo(Long memberId, ChannelControllerEnums status) {
+    public MyChannelMemberShowAllResponse findAllChannelMyInfo(Long memberId, ChannelControllerEnums status, PageParamRequest pageParamRequest) {
+
         List<ChannelMember> myChannelMembers = channelMemberRepository.findByMemberId(memberId);
 
-        return myChannelMembers.stream()
+        List<MyChannelMemberResponse> filteredList = myChannelMembers.stream()
                 .filter(channelMember ->
                         status == ChannelControllerEnums.SHOWALL ||
                                 (status == ChannelControllerEnums.MADEALL && channelMember.getRole() == Role.OWNER) ||
@@ -65,7 +67,16 @@ public class MemberService {
                 )
                 .map(MemberService::buildChannelMemberResponse)
                 .toList();
+
+        Pageable pageable = PageRequest.of(pageParamRequest.getPage(), pageParamRequest.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<MyChannelMemberResponse> page = getPage(pageable, filteredList);
+
+        return MyChannelMemberShowAllResponse.builder()
+                .myChannelMemberResponse(page.getContent())
+                .pageParamResponse(createPageParamResponse(page))
+                .build();
     }
+
 
     private static MyChannelMemberResponse buildChannelMemberResponse(ChannelMember channelMember) {
         return MyChannelMemberResponse.builder()
@@ -89,10 +100,11 @@ public class MemberService {
 
 
     @Transactional(readOnly = true)
-    public List<ChannelFriendResponse> findChannelFriends(Long memberId) {
+    public ChannelFriendShowAllResponse findChannelFriends(Long memberId, PageParamRequest pageParamRequest) {
+
         List<ChannelMember> meOnChannel = channelMemberRepository.findMeOnChannel(memberId);
 
-        return meOnChannel.stream()
+        List<ChannelFriendResponse> filteredList = meOnChannel.stream()
                 .flatMap(me -> me.getChannel().getChannelMembers().stream()
                         .filter(friend -> !friend.equals(me))
                         .map(friend -> ChannelFriendResponse.builder()
@@ -103,6 +115,14 @@ public class MemberService {
                                 .build())
                 )
                 .toList();
+
+        Pageable pageable = PageRequest.of(pageParamRequest.getPage(), pageParamRequest.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<ChannelFriendResponse> page = getPage(pageable, filteredList);
+
+        return ChannelFriendShowAllResponse.builder()
+                .channelFriendResponseList(page.getContent())
+                .pageParamResponse(createPageParamResponse(page))
+                .build();
     }
 
     public ImageResponse uploadProfileImage(Long memberId, MultipartFile file) {
@@ -152,5 +172,21 @@ public class MemberService {
                 .email(member.getEmail())
                 .profileImage(member.getProfileImageUrl())
                 .build();
+    }
+
+    private <T> Page<T> getPage(Pageable pageable, List<T> list) {
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), list.size());
+        return new PageImpl<>(list.subList(start, end), pageable, list.size());
+    }
+
+    private PageParamResponse createPageParamResponse(Page<?> page) {
+        return new PageParamResponse(
+                page.getNumber(),
+                page.getSize(),
+                (int) page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext()
+        );
     }
 }


### PR DESCRIPTION
## What is this PR? :mag:
List로 값을 전달하는 api는 모두 페이지네이션을 구현 완료했습니다.


## Changes :memo:
아래의 스크린샷과 같이 반환값에 봔환해야 되는 List들과 페이지 정보를 같이 반환합니다.

추가적으로 답변 관련해서 최신순 및 오래된순도 같이 개발했습니다.

### PageParamRequest 나 PageParamResponse 는 일단은 common/dto 경로에 만들어 놨습니다.
웬만해선 기존 코드에서 많이 고치지 않고 Response Dto 들을 변경하여 코드를 리팩토링 진행했습니다.


```
 if(filter.equals("DESC")){
            pageable = PageRequest.of(pageParamRequest.getPage(), pageParamRequest.getSize(), Sort.by(Sort.Direction.DESC, "createdAt"));
        }
        else if(filter.equals("ASC")){
            pageable = PageRequest.of(pageParamRequest.getPage(), pageParamRequest.getSize(), Sort.by(Sort.Direction.ASC, "createdAt"));
        }
        else{
            throw new ApiException(ErrorCode.BAD_REQUEST,"filter값을 확인해주세요");
        }

```

대부분 최신 조회하기 , 오래된 순 조회하기 필터들은 페이지네이션이랑 같이 적용되더라구요 
그래서 동흠님께서 만든 최신순, 오래된 순이랑 제가 만든 페이지네이션이랑 충돌이 있어서 
일단은 보수적으로 남겨났습니다. 

또한 동흠님께서 만든 sort 파라미터랑 제가 만든 페이지 네이션 둘이 충돌할 때는 
페이지 네이션 코드쪽으로 살려두었습니다.

정렬하기 기능은 위쪽 코드 사용하면 쉽게 해결할 수 있어서 그랬습니다.

PR읽어 보신후  merge가 되면 필요없는 url 들 삭제 및 response에서 일단은 보수적으로 남겨놓은 데이터가 있습니다. 
그 부분 수정하고 정렬기능들 리펙토링 하겠습니다.


## Screenshot :camera:
![image](https://github.com/user-attachments/assets/7a2db0b7-64f7-4059-ab1a-d260208f5890)
