### PR TITLE
[fix] : 방 개설 전에 사용자의 이름설정을 안할시 오류가 발생하도록 구현했던거 복구

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/KakaoAuthExchangeController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/KakaoAuthExchangeController.java
@@ -59,10 +59,6 @@ public class KakaoAuthExchangeController {
                     : null;
         }
 
-        if(member.getNickName()==null&&channelCount!=0){
-            throw new ApiException(ErrorCode.NULL_POINT,"해당 유저는 이름설정 없이 방을 만들었습니다.");
-        }
-
         UserResponse userResponse = UserResponse.builder()
                 .accessToken(newAccessToken)
                 .refreshToken(refreshToken)


### PR DESCRIPTION
## What is this PR? :mag:

## Changes :memo:

## Screenshot :camera:
