### PR TITLE
[feat] 질문 삭제 및 답변 삭제시 softDelete => 튜플 행 삭제로 변경

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/controller/answer/AnswerController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/answer/AnswerController.java
@@ -68,7 +68,8 @@ public class AnswerController {
     public Api<String> deleteAnswer(
             @PathVariable("answerId") Long answerId
     ){
-        Long deletedId = answerService.delete(answerId);
-        return Api.OK("삭제완료 answerId : "+deletedId);
+         answerService.delete(answerId);
+
+        return Api.OK("삭제완료 answerId : "+ answerId);
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/answer/Answer.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/answer/Answer.java
@@ -37,8 +37,6 @@ public class Answer extends BaseEntity {
     @Column(nullable = false, length = 500)
     private String content;
 
-
-
     @Column(nullable = false)
     private boolean isAnonymous;
 

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -56,7 +56,7 @@ public class Channel extends BaseEntity implements Persistable<String> {
     private List<ChannelMember> channelMembers = new ArrayList<>();
 
 
-    @OneToMany(mappedBy = "channel", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "channel",orphanRemoval = true, fetch = FetchType.LAZY)
     private List<Question> questions = new ArrayList<>();
 
     protected Channel() {}

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/question/Question.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/question/Question.java
@@ -48,7 +48,7 @@ public class Question extends BaseEntity {
     @Column(nullable = false)
     private LocalDate createdDate;
 
-    @OneToMany(mappedBy = "question", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "question",orphanRemoval = true,  fetch = FetchType.LAZY)
     private List<Answer> answerList = new ArrayList<>();
 
     protected Question() {

--- a/src/main/java/com/dnd12th_4/pickitalki/service/answer/AnswerService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/answer/AnswerService.java
@@ -44,13 +44,21 @@ public class AnswerService {
 
         ChannelMember channelMember = getChannelMember(member, question);
 
-        //내가 오늘 post 적었는지 안적었는지
-
+        validateTodayRespond(memberId, question);
 
         Answer answer = new Answer(question, channelMember, requestForm.answerForm(), requestForm.isAnonymous(), requestForm.anonymousName());
         answerRepository.save(answer);
 
         return toAnswerWriteResponse(answer, member);
+    }
+
+    private void validateTodayRespond(Long memberId, Question question) {
+        boolean alreadyAnswered = question.getAnswerList().stream()
+                .anyMatch(answer -> answer.getAuthor().isSameMember(memberId));
+
+        if (alreadyAnswered) {
+            throw new ApiException(ErrorCode.BAD_REQUEST, "이 사용자는 이미 오늘의 질문에 답을 했습니다.");
+        }
     }
 
     @Transactional

--- a/src/main/java/com/dnd12th_4/pickitalki/service/answer/AnswerService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/answer/AnswerService.java
@@ -44,6 +44,8 @@ public class AnswerService {
 
         ChannelMember channelMember = getChannelMember(member, question);
 
+        //내가 오늘 post 적었는지 안적었는지
+
 
         Answer answer = new Answer(question, channelMember, requestForm.answerForm(), requestForm.isAnonymous(), requestForm.anonymousName());
         answerRepository.save(answer);
@@ -85,12 +87,12 @@ public class AnswerService {
     }
 
     @Transactional
-    public Long delete(Long answerId) {
+    public void delete(Long answerId) {
         Answer answer = answerRepository.findById(answerId)
                 .orElseThrow(() -> new ApiException(ErrorCode.BAD_REQUEST, "AnswerInfoResponse delete 해당 answerId는 DB에 없습니다."));
 
-        answer.softDelete();
-        return answer.getId();
+        Question question = answer.getQuestion();
+        question.getAnswerList().remove(answer);
     }
 
     private AnswerResponse toAnswerResponse(Answer answer, Long memberId) {

--- a/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/question/QuestionService.java
@@ -176,7 +176,8 @@ public class QuestionService {
             throw new IllegalArgumentException("해당 질문을 삭제할 권한이 없습니다.");
         }
 
-        question.softDelete();
+        Channel channel = question.getChannel();
+        channel.getQuestions().remove(question);
 
     }
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,4 @@
-create TABLE if not exists `pickitalki`.members
+CREATE TABLE IF NOT EXISTS `pickitalki`.members
 (
     id                BIGINT AUTO_INCREMENT PRIMARY KEY,
     kakao_id          BIGINT UNIQUE NOT NULL,
@@ -7,68 +7,68 @@ create TABLE if not exists `pickitalki`.members
     profile_image_url TEXT          NULL,
     refresh_token     TEXT          NULL,
     created_at        DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        DATETIME      DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
+    updated_at        DATETIME               DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     is_deleted        TINYINT(1)    NOT NULL DEFAULT 0
 );
 
-create TABLE if not exists `pickitalki`.channels
+CREATE TABLE IF NOT EXISTS `pickitalki`.channels
 (
-    uuid       BINARY(16) PRIMARY KEY,
-    name       VARCHAR(30) NOT NULL UNIQUE,
-    invite_code VARCHAR(6) NOT NULL UNIQUE,
-    point INT NOT NULL DEFAULT 0,
-    created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME    DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-    is_deleted TINYINT(1)  NOT NULL DEFAULT 0
+    uuid        BINARY(16) PRIMARY KEY,
+    name        VARCHAR(10) NOT NULL UNIQUE,
+    invite_code VARCHAR(6)  NOT NULL UNIQUE,
+    point       INT         NOT NULL DEFAULT 0,
+    created_at  DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME             DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    is_deleted  TINYINT(1)  NOT NULL DEFAULT 0
 );
 
-create TABLE if not exists `pickitalki`.channel_members
+
+CREATE TABLE IF NOT EXISTS `pickitalki`.channel_members
 (
-    id               BIGINT AUTO_INCREMENT PRIMARY KEY,
-    channel_uuid     BINARY(16)  NOT NULL,
-    member_id        BIGINT      NOT NULL,
-    member_code_name VARCHAR(20),
-    profile_image TEXT NULL,
-    is_using_default_profile TINYINT(1) NOT NULL DEFAULT 1,
-    role             VARCHAR(10) NOT NULL,
-    created_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at       DATETIME    DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-    is_deleted       TINYINT(1)  NOT NULL DEFAULT 0,
-    FOREIGN KEY (channel_uuid) REFERENCES channels (uuid),
+    id                       BIGINT AUTO_INCREMENT PRIMARY KEY,
+    channel_uuid             BINARY(16)  NOT NULL,
+    member_id                BIGINT      NOT NULL,
+    member_code_name         VARCHAR(20) NULL,
+    profile_image            TEXT        NULL,
+    is_using_default_profile TINYINT(1)  NOT NULL DEFAULT 1,
+    role                     VARCHAR(10) NOT NULL,
+    created_at               DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at               DATETIME             DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    is_deleted               TINYINT(1)  NOT NULL DEFAULT 0,
+    FOREIGN KEY (channel_uuid) REFERENCES channels (uuid) ON DELETE CASCADE,
     FOREIGN KEY (member_id) REFERENCES members (id)
 );
 
-create TABLE if not exists `pickitalki`.questions
+
+CREATE TABLE IF NOT EXISTS `pickitalki`.questions
 (
-    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
-    channel_uuid   BINARY(16)   NOT NULL,
-    channel_member_id      BIGINT       NOT NULL,
-    content        VARCHAR(255) NOT NULL,
-    question_number BIGINT NOT NULL,
-    is_anonymous   BOOLEAN      NOT NULL DEFAULT FALSE,
-    anonymous_name VARCHAR(30),
-    created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    created_date   DATE     NOT NULL,
-    updated_at     DATETIME     DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-    is_deleted     TINYINT(1)   NOT NULL DEFAULT 0,
+    id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+    channel_uuid      BINARY(16)   NOT NULL,
+    channel_member_id BIGINT       NOT NULL,
+    content           VARCHAR(255) NOT NULL,
+    question_number   BIGINT       NOT NULL,
+    is_anonymous      BOOLEAN      NOT NULL DEFAULT FALSE,
+    anonymous_name    VARCHAR(30)  NULL,
+    created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_date      DATE         NOT NULL,
+    updated_at        DATETIME              DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    is_deleted        TINYINT(1)   NOT NULL DEFAULT 0,
     CONSTRAINT unique_channel_today_question UNIQUE (channel_uuid, created_date),
     FOREIGN KEY (channel_uuid) REFERENCES channels (uuid),
-    FOREIGN KEY (channel_member_id) REFERENCES channel_members (id)
-
+    FOREIGN KEY (channel_member_id) REFERENCES channel_members (id) ON DELETE CASCADE
 );
-
-create TABLE if not exists `pickitalki`.answers
+CREATE TABLE IF NOT EXISTS `pickitalki`.answers
 (
-    id             BIGINT AUTO_INCREMENT PRIMARY KEY,
-    question_id    BIGINT       NOT NULL,
-    member_id      BIGINT       NOT NULL,
-    content        VARCHAR(500) NOT NULL,
-    is_anonymous   BOOLEAN      NOT NULL DEFAULT FALSE,
-    anonymous_name VARCHAR(10),
-    created_at     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at     DATETIME     DEFAULT CURRENT_TIMESTAMP ON update CURRENT_TIMESTAMP,
-    is_deleted     TINYINT(1)   NOT NULL DEFAULT 0,
+    id                BIGINT AUTO_INCREMENT PRIMARY KEY,
+    question_id       BIGINT       NOT NULL,
+    channel_member_id BIGINT       NOT NULL,
+    content           VARCHAR(500) NOT NULL,
+    is_anonymous      BOOLEAN      NOT NULL DEFAULT FALSE,
+    anonymous_name    VARCHAR(30),
+    created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        DATETIME              DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    is_deleted        TINYINT(1)   NOT NULL DEFAULT 0,
     FOREIGN KEY (question_id) REFERENCES questions (id),
-    FOREIGN KEY (member_id) REFERENCES members (id)
+    FOREIGN KEY (channel_member_id) REFERENCES channel_members (id)
 );
 


### PR DESCRIPTION
## What is this PR? :mag:
질문 삭제 및 답변 삭제시 softDelete => 튜플 행 삭제로 변경했습니다.


## Changes :memo:

orphanRemoval = true 를 사용했습니다.

softDelete를 하게 될 경우 실제로 튜플 행에서 사라진게 아니라 외래키 제약 조건에 문제가 생기는 현상이 발생햇습니다.

예를들어 오늘의 질문을 만들고 오늘의 질문을 softDelete를 통해 지웠다고 가정하면
실제 디비에는 오늘의 질문의 저장되어 있습니다. 
이로인해 다시 질문을 만들려고 하면 외래키 제약 조건으로 인해 만들지 못하는 현상이 발생했습니다.

answer부분 또한 위와 비슷한 오류가 있어서 시행했습니다.

## Screenshot :camera:
