### PR TITLE
[feat] :  refresh 토큰을 디비에 저장할 때 암호화 하여 개발자가 알지 못하도록 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 	//swagger-ui
 	//http://localhost:8080/swagger-ui/index.html  << 반드시 이 url 로 접속
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	//BcryptUtil
+	implementation 'org.mindrot:jbcrypt:0.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dnd12th_4/pickitalki/common/token/SHA256Util.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/token/SHA256Util.java
@@ -1,0 +1,21 @@
+package com.dnd12th_4.pickitalki.common.token;
+
+import org.mindrot.jbcrypt.BCrypt;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class SHA256Util {
+    public static String hash(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes());
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (Exception e) {
+            throw new RuntimeException("Error while hashing", e);
+        }
+    }
+
+
+}

--- a/src/main/java/com/dnd12th_4/pickitalki/controller/login/TokenAuthController.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/controller/login/TokenAuthController.java
@@ -37,9 +37,11 @@ public class TokenAuthController {
             @RequestHeader(value = "Authorization", required = false) String refreshToken,
             HttpServletResponse response) {
 
+        refreshToken = subBerar(refreshToken);
+
         Member user = kaKaoSignUpService.findUser(refreshToken);
 
-        if (jwtProvider.isTokenExpired(user.getRefreshToken())) {
+        if (jwtProvider.isTokenExpired(refreshToken)) {
             executeExpiredCookie(response, user);
 
              throw new ApiException(TokenErrorCode.EXPIRED_TOKEN,"ResponseEntity refreshAccessToken 에러");
@@ -48,6 +50,13 @@ public class TokenAuthController {
         RefreshTokenResponse refreshTokenResponse = getRefreshTokenResponse(user);
 
         return Api.OK(refreshTokenResponse);
+    }
+
+    private  String subBerar(String refreshToken) {
+        if(refreshToken.startsWith("Bearer ")){
+            refreshToken = refreshToken.substring(7);
+        }
+        return refreshToken;
     }
 
     private RefreshTokenResponse getRefreshTokenResponse(Member user) {

--- a/src/main/java/com/dnd12th_4/pickitalki/service/login/KaKaoSignUpService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/login/KaKaoSignUpService.java
@@ -1,5 +1,6 @@
 package com.dnd12th_4.pickitalki.service.login;
 
+import com.dnd12th_4.pickitalki.common.token.SHA256Util;
 import com.dnd12th_4.pickitalki.controller.login.dto.response.KakaoUserDto;
 import com.dnd12th_4.pickitalki.domain.member.Member;
 import com.dnd12th_4.pickitalki.domain.member.MemberRepository;
@@ -45,11 +46,9 @@ public class KaKaoSignUpService {
 
     public Member findUser(String token) {
 
-        if(token.startsWith("Bearer ")){
-            token = token.substring(7);
-        }
+        String hashedRefreshToken = SHA256Util.hash(token);
 
-        return memberRepository.findByRefreshToken(token)
-                .orElseThrow(() -> new ApiException(TokenErrorCode.INVALID_TOKEN, "Member findUser 48번째줄 에러"));
+        return memberRepository.findByRefreshToken(hashedRefreshToken)
+                .orElseThrow(() -> new ApiException(TokenErrorCode.INVALID_TOKEN, "refreshToken 을 가진 사용자는 없습니다. 위치 : findUser"));
     }
 }


### PR DESCRIPTION
## What is this PR? :mag:
기존 refreshToken 자체를 데이터베이스에 저장했습니다. 
이렇게 되면 개발자가 마음만 먹으면 refreshToken을 이용하여 AccessToken을 발급받아 언제든지 로그인 할 수 있는 문제점이
있었습니다.


## Changes :memo:
그래서 해결방법은 refreshToken원본은 client에게 전달하고 
데이터베이스에 저장할 때는 refreshToken을 암호화를 하여 아래와 같은 그림처럼 알 수 없도록 저장했습니다.

만약 유저가 원본 refreshToken을 이용하여 재발급 요청이 들어오면 
암호화 알고리즘을 이용하여 refreshToken을 암호화한 뒤 (원본이 같으면 같은 형태의 암호화된 값이 나옵니다.)
데이터 베이스의 있는 암호화된 refreshToken과 비교를 한 뒤 같다면 accessToken을 반환해주는 형식으로 
코드를 작성했습니다.

아래에 있는 첫번째 사진은 데이터베이스 사진이고
두번째 있는 사진은 유저가 원본 refreshToken을 받는 사진입니다.


## Screenshot :camera:
![image](https://github.com/user-attachments/assets/b7b9d4e6-5444-4839-858c-84e18eb711c5)
![image](https://github.com/user-attachments/assets/d94c81bf-dc0a-4085-9324-beb6b80099ce)
