### PR TITLE
[Fix] questioner Boolean isTodayQuestioner 변수가 항상 True였던 문제 fix

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -2,6 +2,7 @@ package com.dnd12th_4.pickitalki.service.channel;
 
 import com.dnd12th_4.pickitalki.common.config.AppConfig;
 import com.dnd12th_4.pickitalki.common.dto.response.PageParamResponse;
+import com.dnd12th_4.pickitalki.common.pagination.Pagination;
 import com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums;
 import com.dnd12th_4.pickitalki.controller.channel.dto.ChannelMemberDto;
 import com.dnd12th_4.pickitalki.controller.channel.dto.response.ChannelJoinResponse;
@@ -122,11 +123,11 @@ public class ChannelService {
                 .map(this::buildChannelShowAllResponse)
                 .toList();
 
-        Page<ChannelShowResponse> page = getPage(pageable, filteredList);
+        Page<ChannelShowResponse> page = Pagination.getPage(pageable, filteredList);
 
         return ChannelShowAllResponse.builder()
                 .channelShowResponse(page.getContent())
-                .pageParamResponse(createPageParamResponse(page))
+                .pageParamResponse(Pagination.createPageParamResponse(page))
                 .build();
     }
 
@@ -210,9 +211,9 @@ public class ChannelService {
                         .build()
                 ).toList();
 
-        Page<ChannelMemberDto> page = getPage(pageable, filteredList);
+        Page<ChannelMemberDto> page = Pagination.getPage(pageable, filteredList);
 
-        return new ChannelMembersResponse(channel.getName(),page.getContent().size(), page.getContent(), createPageParamResponse(page));
+        return new ChannelMembersResponse(channel.getName(),page.getContent().size(), page.getContent(), Pagination.createPageParamResponse(page));
     }
 
     @Transactional
@@ -246,8 +247,14 @@ public class ChannelService {
                 .channelMemberId(todayQuestioner.getId())
                 .codeName(todayQuestioner.getMemberCodeName())
                 .profileImageUrl(todayQuestioner.getProfileImage())
-                .isTodayQuestioner(true)
+                .isTodayQuestioner(isMyTodayQuestioner(todayQuestioner.getId(),memberId))
                 .build();
+    }
+
+    private boolean isMyTodayQuestioner(Long questionerId , Long memberId){
+        if(questionerId.equals(memberId)) return true;
+
+        return false;
     }
 
     private ChannelMember findTodayQuestioner(Channel channel) {
@@ -332,21 +339,6 @@ public class ChannelService {
                 .build();
     }
 
-    private <T> Page<T> getPage(Pageable pageable, List<T> list) {
-        int start = (int) pageable.getOffset();
-        int end = Math.min(start + pageable.getPageSize(), list.size());
-        return new PageImpl<>(list.subList(start, end), pageable, list.size());
-    }
-
-    private PageParamResponse createPageParamResponse(Page<?> page) {
-        return new PageParamResponse(
-                page.getNumber(),
-                page.getSize(),
-                (int) page.getTotalElements(),
-                page.getTotalPages(),
-                page.hasNext()
-        );
-    }
 
     @Transactional
     public void leaveChannel(Long memberId, String channelId) {

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -247,7 +247,7 @@ public class ChannelService {
                 .channelMemberId(todayQuestioner.getId())
                 .codeName(todayQuestioner.getMemberCodeName())
                 .profileImageUrl(todayQuestioner.getProfileImage())
-                .isTodayQuestioner(isMyTodayQuestioner(todayQuestioner.getId(),memberId))
+                .isTodayQuestioner(isMyTodayQuestioner(todayQuestioner.getMember().getId(),memberId))
                 .build();
     }
 


### PR DESCRIPTION
## What is this PR? :mag:
[Fix] questioner Boolean isTodayQuestioner 변수가 항상 True였던 문제 fix

### 이전 refreshToken PR내용이 같이 있네요.. 따로 하이퍼링크를 달아 놓겠습니다.
### <a href="https://github.com/dnd-side-project/dnd-12th-4-backend/pull/61/files/6ec163fbbbe88c66753f6f6b23803a12e874865b..8095406094949659bf04846515ed742b51304810">변경된 커밋 내용</a>
## Changes :memo:

api의 의도한 바가 맞는지 궁금하여 PR남겨봅니다.
기존 코드에서 isTodayQuestioner는 항상 True였습니다.
그래서 오늘 내가 질문하는 사람이 아니라면 false를 반환하게 리팩토링 했습니다.

## Screenshot :camera:
![image](https://github.com/user-attachments/assets/0183d320-eb63-44b1-9839-aaf1617f6261)
