### PR TITLE
[fix] image url의 기본주소가 매핑 안되는 오류 해결

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/common/config/AppConfig.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/common/config/AppConfig.java
@@ -16,7 +16,7 @@ public class AppConfig {
         return new RestTemplate();
     }
 
-    public static String getBaseUrl() {
+    public String getBaseUrl() {
         return baseUrl;
     }
 }

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -53,6 +53,7 @@ public class ChannelService {
     private final MemberRepository memberRepository;
     private final ChannelMemberRepository channelMemberRepository;
     private final QuestionRepository questionRepository;
+    private final AppConfig appConfig;
 
     @Transactional
     public ChannelResponse save(Long memberId, String channelName, String codeName) {
@@ -302,7 +303,7 @@ public class ChannelService {
                 .channelId(channel.getId())
                 .level(channel.getLevel())
                 .point(channel.getPoint())
-                .characterImageUri(AppConfig.getBaseUrl()+ChannelLevel.getImageByLevel(channel.getLevel()))
+                .characterImageUri(appConfig.getBaseUrl()+ChannelLevel.getImageByLevel(channel.getLevel()))
                 .build();
         //TODO 멤버의 조회 시에 오늘 채널 몇개 중에 몇개의 응답을 했는지 정보 반환하는 api필요
     }


### PR DESCRIPTION
## What is this PR? :mag:
아래 상황에서 image url 매핑이 안되 null 포함되는 오류 수정
<img width="1072" alt="스크린샷 2025-02-17 오후 1 10 24" src="https://github.com/user-attachments/assets/416d0793-b973-4edb-9370-aca3d3b22f27" />

## Screenshot :camera:
