### PR TITLE
[feat] 채널 멤버의 탈퇴 시에도 관련 질문,답변은 조회가능하게 소프트 딜리트 적용

### DIFF
--- a/src/main/java/com/dnd12th_4/pickitalki/domain/BaseEntity.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/BaseEntity.java
@@ -36,6 +36,10 @@ public abstract class BaseEntity {
         this.isDeleted = true;
     }
 
+    public void softRestore() {
+        this.isDeleted = false;
+    }
+
 }
 
 

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/Channel.java
@@ -58,7 +58,7 @@ public class Channel extends BaseEntity implements Persistable<String> {
     private int point;
 
     @OneToMany(mappedBy = "channel", cascade = {PERSIST, MERGE, REMOVE},orphanRemoval = true, fetch = FetchType.LAZY)
-    @SQLRestriction("channel_members.is_deleted = false")
+    @SQLRestriction("is_deleted = false")
     private List<ChannelMember> channelMembers = new ArrayList<>();
 
 

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -17,6 +17,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.Objects;
 
@@ -24,6 +25,7 @@ import static java.util.Objects.hash;
 import static java.util.Objects.isNull;
 
 @Getter
+@SQLRestriction("channel_members.is_deleted = false")
 @Table(name = "channel_members")
 @Entity
 @SuperBuilder

--- a/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/domain/channel/ChannelMember.java
@@ -25,7 +25,7 @@ import static java.util.Objects.hash;
 import static java.util.Objects.isNull;
 
 @Getter
-@SQLRestriction("channel_members.is_deleted = false")
+@SQLRestriction("is_deleted = false")
 @Table(name = "channel_members")
 @Entity
 @SuperBuilder

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -35,7 +35,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 import java.util.UUID;
 
 import static com.dnd12th_4.pickitalki.controller.channel.ChannelControllerEnums.INVITEDALL;
@@ -344,8 +343,8 @@ public class ChannelService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 채널에 참여해 있지 않습니다. 탈퇴할 수 없습니다."));
 
         channel.leaveChannel(channelMember);
+        channel.pickNewOwnerIfVacant();
         deleteIfChannelEmpty(channel, channelUuid, channelMember);
-        pickNewOwnerIfOwnerLeave(channel, channelMember);
     }
 
     private void deleteIfChannelEmpty(Channel channel, UUID channelUuid, ChannelMember channelMember) {
@@ -353,15 +352,6 @@ public class ChannelService {
             channelRepository.deleteById(channelUuid);
         }
     }
-
-    private void pickNewOwnerIfOwnerLeave(Channel channel, ChannelMember channelMember) {
-        if (channelMember.getRole() == Role.OWNER) {
-            channel.getChannelMembers()
-                    .get(new Random().nextInt(channel.getChannelMembers().size()))
-                    .changeRole(Role.OWNER);
-        }
-    }
-
 
     @Transactional
     public void leaveChannels(Long memberId, List<String> channelIds) {

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -205,7 +205,7 @@ public class ChannelService {
         List<ChannelMemberDto> filteredList = channelMemberList.getContent()
                 .stream().map(channelMember -> ChannelMemberDto.builder()
                         .codeName(channelMember.getMemberCodeName())
-                        .profileImageUrl(channelMember.getMember().getProfileImageUrl())
+                        .profileImageUrl(channelMember.getProfileImage())
                         .channelMemberId(channelMember.getId())
                         .build()
                 ).toList();
@@ -228,7 +228,7 @@ public class ChannelService {
         return ChannelMemberProfileResponse.builder()
                 .channelMemberId(channelMember.getId())
                 .codeName(channelMember.getMemberCodeName())
-                .profileImageUrl(channelMember.getMember().getProfileImageUrl())
+                .profileImageUrl(channelMember.getProfileImage())
                 .isTodayQuestioner(channelMember.getId().equals(todayQuestioner.getId()))
                 .build();
     }
@@ -309,7 +309,6 @@ public class ChannelService {
                 .point(channel.getPoint())
                 .characterImageUri(appConfig.getBaseUrl() + ChannelLevel.getImageByLevel(channel.getLevel()))
                 .build();
-        //TODO 멤버의 조회 시에 오늘 채널 몇개 중에 몇개의 응답을 했는지 정보 반환하는 api필요
     }
 
     @Transactional

--- a/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
+++ b/src/main/java/com/dnd12th_4/pickitalki/service/channel/ChannelService.java
@@ -27,6 +27,7 @@ import com.dnd12th_4.pickitalki.domain.question.QuestionRepository;
 import com.dnd12th_4.pickitalki.presentation.error.ErrorCode;
 import com.dnd12th_4.pickitalki.presentation.exception.ApiException;
 import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -152,19 +153,19 @@ public class ChannelService {
                 .build();
     }
 
-    @Transactional(readOnly= true)
+    @Transactional(readOnly = true)
     public String findInviteCode(Long memberId, String channelName) {
         Channel channel = channelRepository.findByName(channelName)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이름의 채널을 찾을 수 없습니다. 초대코드를 응답할 수 없습니다."));
 
 
-       channel.findChannelMemberById(memberId)
+        channel.findChannelMemberById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("채널에 해당 회원이 존재하지 않습니다. 초대코드를 열람할 권한이 없습니다."));
         return channel.getInviteCode();
 
     }
 
-    @Transactional(readOnly= true)
+    @Transactional(readOnly = true)
     public ChannelSpecificResponse findChannelByChannelName(Long memberId, String channelName) {
         Channel channel = channelRepository.findByName(channelName)
                 .orElseThrow(() -> new IllegalArgumentException("해당 이름의 채널을 찾을 수 없습니다. 채널정보를 응답할 수 없습니다."));
@@ -190,7 +191,7 @@ public class ChannelService {
 
     }
 
-    @Transactional(readOnly= true)
+    @Transactional(readOnly = true)
     public ChannelMembersResponse findChannelMembers(Long memberId, String channelId, Pageable pageable) {
         UUID channelUuid = UUID.fromString(channelId);
         Channel channel = channelRepository.findByUuid(channelUuid)
@@ -211,7 +212,7 @@ public class ChannelService {
 
         Page<ChannelMemberDto> page = Pagination.getPage(pageable, filteredList);
 
-        return new ChannelMembersResponse(channel.getName(),page.getContent().size(), page.getContent(), Pagination.createPageParamResponse(page));
+        return new ChannelMembersResponse(channel.getName(), page.getContent().size(), page.getContent(), Pagination.createPageParamResponse(page));
     }
 
     @Transactional
@@ -231,6 +232,7 @@ public class ChannelService {
                 .isTodayQuestioner(channelMember.getId().equals(todayQuestioner.getId()))
                 .build();
     }
+
     @Transactional
     public ChannelMemberProfileResponse findTodayQuestioner(Long memberId, String channelId) {
         UUID channelUuid = UUID.fromString(channelId);
@@ -239,15 +241,18 @@ public class ChannelService {
         ChannelMember channelMember = channel.findChannelMemberById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("채널에 해당 회원이 존재하지 않습니다. 오늘의 질문자를 조회할 권한이 없습니다."));
 
-        ChannelMember todayQuestioner = findTodayQuestioner(channel);
+        try {
+            ChannelMember todayQuestioner = findTodayQuestioner(channel);
 
-
-        return ChannelMemberProfileResponse.builder()
-                .channelMemberId(todayQuestioner.getId())
-                .codeName(todayQuestioner.getMemberCodeName())
-                .profileImageUrl(todayQuestioner.getProfileImage())
-                .isTodayQuestioner(todayQuestioner.getMember().getId().equals(memberId))
-                .build();
+            return ChannelMemberProfileResponse.builder()
+                    .channelMemberId(todayQuestioner.getId())
+                    .codeName(todayQuestioner.getMemberCodeName())
+                    .profileImageUrl(todayQuestioner.getProfileImage())
+                    .isTodayQuestioner(todayQuestioner.getMember().getId().equals(memberId))
+                    .build();
+        } catch (EntityNotFoundException e) {
+            throw new IllegalArgumentException("오늘의 질문자가 탈퇴하였습니다. 회원 정보를 제공할 수 없습니다.");
+        }
     }
 
 
@@ -260,7 +265,6 @@ public class ChannelService {
         } else {
             todayQuestioner = channel.pickTodayQuestioner();
         }
-
         return todayQuestioner;
     }
 
@@ -303,7 +307,7 @@ public class ChannelService {
                 .channelId(channel.getId())
                 .level(channel.getLevel())
                 .point(channel.getPoint())
-                .characterImageUri(appConfig.getBaseUrl()+ChannelLevel.getImageByLevel(channel.getLevel()))
+                .characterImageUri(appConfig.getBaseUrl() + ChannelLevel.getImageByLevel(channel.getLevel()))
                 .build();
         //TODO 멤버의 조회 시에 오늘 채널 몇개 중에 몇개의 응답을 했는지 정보 반환하는 api필요
     }


### PR DESCRIPTION
## What is this PR? :mag:
우선 도메인 Channel 클래스와 ChannelMember 클래스를 유심히 보셔야 합니다.
soft delete가 적용되도록 어노테이션을 추가했습니다.

그리고 아래의 getChannelMembers 관련해서 중요하게 알아야 하는 게 있습니다. 해당 메서드는 불변리스트를 반환합니다.
<img width="798" alt="image" src="https://github.com/user-attachments/assets/efa09fe1-68a6-4e11-bbde-55bc3bfde8d7" />

즉, **Channel.getChannelMembers() 함수에서 얻은 리스트는 조회시의 필터링에만 사용가능하고, 이 리스트를 통해 channelMember의 속성을 변경하려하면 에러가 발생합니다**. 예를 들어, 해당 리스트를 통해 channelMember의 role을 바꾸려하면 에러가 발생합니다.

때문에 업데이트가 필요한 로직에는 getChannelMembers()를 사용하는 게 아니라 channel의 메서드를 통해 수정을 요청해야합니다. 그러면 channel 내부 메서드에서는 channelMembers 를 직접 이용해 변경감지로 업데이트를 할 수 있습니다. 

+ 소프트 딜리트는 될 것 같은데, 모든 질문과 답변 조회에서 이미 탈퇴한 멤버의 것도 잘 조회되는 지는 확실하지는 않습니다.
추후 조회 로직에서 수정사항이 발생할 수 있습니다

+ 채널맴버 조회시 변경된 프로필 이미지url을 반환하지 않던 오류 수정
## Changes :memo:

## Screenshot :camera:
